### PR TITLE
Add React frontend documentation console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+frontend/node_modules/
+frontend/dist/
+frontend/.vite/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        default-libmysqlclient-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY fhir_portal/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY fhir_portal/ /app/
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.9"
+
+services:
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: fhir_portal
+      MYSQL_USER: fhir_user
+      MYSQL_PASSWORD: fhir_password
+      MYSQL_ROOT_PASSWORD: root_password
+    command: ["--default-authentication-plugin=mysql_native_password", "--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]
+    volumes:
+      - mysql-data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    working_dir: /app
+    volumes:
+      - ./fhir_portal:/app
+    environment:
+      MYSQL_DATABASE: fhir_portal
+      MYSQL_USER: fhir_user
+      MYSQL_PASSWORD: fhir_password
+      MYSQL_HOST: db
+      MYSQL_PORT: 3306
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+
+volumes:
+  mysql-data:

--- a/fhir_portal/FHIR_Patient_Portal.postman_collection.json
+++ b/fhir_portal/FHIR_Patient_Portal.postman_collection.json
@@ -1,0 +1,1228 @@
+{
+  "info": {
+    "name": "FHIR Patient Portal API",
+    "description": "Collection covering the stubbed REST endpoints for the Django-based FHIR Patient Portal prototype.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "version": {
+      "major": 1,
+      "minor": 0,
+      "patch": 0
+    }
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{bearerToken}}",
+        "type": "string"
+      }
+    ]
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8000",
+      "type": "string"
+    },
+    {
+      "key": "bearerToken",
+      "value": "sample-jwt-token",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "HL7 Parser Service",
+      "item": [
+        {
+          "name": "HL7 Message Ingestion",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/hl7-v2"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "MSH|^~\\&|SENDING_APP|SENDING_FACILITY|RECEIVING_APP|RECEIVING_FACILITY|20230901123045||ADT^A01\nEVN||20230901123045|||USER123\nPID|||MRN12345||Doe^John^M||19800115|M|||123 Main St^^City^ST^12345^USA||5551234567|\nPV1||I|ICU^101^A|||DOC123^Smith^Jane^MD|||SUR||||A|||DOC123|INS|12345|||||||||||||||||||20230901123045"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/hl7-parser/ingest",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "hl7-parser",
+                "ingest"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Message Parsing Status",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/hl7-parser/parse-status/MSG001",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "hl7-parser",
+                "parse-status",
+                "MSG001"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Batch Processing",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"batchId\": \"batch-001\",\n  \"messages\": [\n    {\n      \"messageId\": \"MSG001\",\n      \"content\": \"MSH|^~\\\\&|...\",\n      \"priority\": \"normal\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/hl7-parser/batch",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "hl7-parser",
+                "batch"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Patient Service",
+      "item": [
+        {
+          "name": "Patient Registration",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/fhir+json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Patient\",\n  \"identifier\": [\n    {\n      \"use\": \"usual\",\n      \"type\": {\n        \"coding\": [\n          {\n            \"system\": \"http://terminology.hl7.org/CodeSystem/v2-0203\",\n            \"code\": \"MR\"\n          }\n        ]\n      },\n      \"value\": \"MRN12345\"\n    }\n  ],\n  \"name\": [\n    {\n      \"use\": \"official\",\n      \"family\": \"Doe\",\n      \"given\": [\"John\", \"Michael\"]\n    }\n  ],\n  \"gender\": \"male\",\n  \"birthDate\": \"1980-01-15\",\n  \"address\": [\n    {\n      \"use\": \"home\",\n      \"line\": [\"123 Main St\"],\n      \"city\": \"Springfield\",\n      \"state\": \"IL\",\n      \"postalCode\": \"62701\",\n      \"country\": \"US\"\n    }\n  ],\n  \"telecom\": [\n    {\n      \"system\": \"phone\",\n      \"value\": \"555-123-4567\",\n      \"use\": \"mobile\"\n    },\n    {\n      \"system\": \"email\",\n      \"value\": \"john.doe@email.com\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/patients/",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "patients"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Patient Profile Update",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/fhir+json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Patient\",\n  \"name\": [\n    {\n      \"family\": \"Doe\",\n      \"given\": [\"John\", \"Michael\"]\n    }\n  ],\n  \"telecom\": [\n    {\n      \"system\": \"phone\",\n      \"value\": \"555-987-6543\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/patients/{{patientId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "patients",
+                "{{patientId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Patient Search",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/patients/search?identifier=MRN12345&name=John&_fuzzy=true",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "patients",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "identifier",
+                  "value": "MRN12345"
+                },
+                {
+                  "key": "name",
+                  "value": "John"
+                },
+                {
+                  "key": "_fuzzy",
+                  "value": "true"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Patient Record Merge",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"reason\": \"Duplicate records identified\",\n  \"mergeStrategy\": \"keep_latest\",\n  \"fields\": [\"contact\", \"address\"],\n  \"auditReason\": \"Data quality improvement\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/patients/{{sourceId}}/merge/{{targetId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "patients",
+                "{{sourceId}}",
+                "merge",
+                "{{targetId}}"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Patient Data Export",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/patients/{{patientId}}/export?format=pdf&includeSections=demographics,vitals,labs,medications",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "patients",
+                "{{patientId}}",
+                "export"
+              ],
+              "query": [
+                {
+                  "key": "format",
+                  "value": "pdf"
+                },
+                {
+                  "key": "includeSections",
+                  "value": "demographics,vitals,labs,medications"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Observation Service",
+      "item": [
+        {
+          "name": "Vital Signs Entry",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Observation\",\n  \"status\": \"final\",\n  \"category\": [\n    {\n      \"coding\": [\n        {\n          \"system\": \"http://terminology.hl7.org/CodeSystem/observation-category\",\n          \"code\": \"vital-signs\"\n        }\n      ]\n    }\n  ],\n  \"code\": {\n    \"coding\": [\n      {\n        \"system\": \"http://loinc.org\",\n        \"code\": \"85354-9\",\n        \"display\": \"Blood pressure panel with all children optional\"\n      }\n    ]\n  },\n  \"subject\": {\n    \"reference\": \"Patient/patient-uuid-123\"\n  },\n  \"effectiveDateTime\": \"2023-09-01T12:30:45Z\",\n  \"component\": [\n    {\n      \"code\": {\n        \"coding\": [\n          {\n            \"system\": \"http://loinc.org\",\n            \"code\": \"8480-6\",\n            \"display\": \"Systolic blood pressure\"\n          }\n        ]\n      },\n      \"valueQuantity\": {\n        \"value\": 120,\n        \"unit\": \"mmHg\",\n        \"system\": \"http://unitsofmeasure.org\",\n        \"code\": \"mm[Hg]\"\n      }\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/observations/",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "observations"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Lab Results Integration",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Bundle\",\n  \"type\": \"transaction\",\n  \"entry\": [\n    {\n      \"request\": {\n        \"method\": \"POST\",\n        \"url\": \"Observation\"\n      },\n      \"resource\": {\n        \"resourceType\": \"Observation\",\n        \"status\": \"final\",\n        \"category\": [\n          {\n            \"coding\": [\n              {\n                \"system\": \"http://terminology.hl7.org/CodeSystem/observation-category\",\n                \"code\": \"laboratory\"\n              }\n            ]\n          }\n        ],\n        \"code\": {\n          \"coding\": [\n            {\n              \"system\": \"http://loinc.org\",\n              \"code\": \"2339-0\",\n              \"display\": \"Glucose\"\n            }\n          ]\n        },\n        \"valueQuantity\": {\n          \"value\": 95,\n          \"unit\": \"mg/dL\",\n          \"system\": \"http://unitsofmeasure.org\"\n        }\n      }\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/observations/lab-results",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "observations",
+                "lab-results"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Trend Visualization Data",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/observations/{{patientId}}/trends?code=2339-0&category=laboratory&period=P30D",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "observations",
+                "{{patientId}}",
+                "trends"
+              ],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "2339-0"
+                },
+                {
+                  "key": "category",
+                  "value": "laboratory"
+                },
+                {
+                  "key": "period",
+                  "value": "P30D"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Clinical Alerts Configuration",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"patientId\": \"patient-uuid-123\",\n  \"observationCode\": \"8480-6\",\n  \"thresholds\": {\n    \"critical\": {\n      \"high\": 180,\n      \"low\": 90\n    },\n    \"warning\": {\n      \"high\": 140,\n      \"low\": 100\n    }\n  },\n  \"notificationChannels\": [\"email\", \"sms\", \"app\"],\n  \"active\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/observations/alerts/configure",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "observations",
+                "alerts",
+                "configure"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Appointment Service",
+      "item": [
+        {
+          "name": "Appointment Booking",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Appointment\",\n  \"status\": \"booked\",\n  \"serviceCategory\": [\n    {\n      \"coding\": [\n        {\n          \"system\": \"http://terminology.hl7.org/CodeSystem/service-category\",\n          \"code\": \"17\",\n          \"display\": \"General Practice\"\n        }\n      ]\n    }\n  ],\n  \"appointmentType\": {\n    \"coding\": [\n      {\n        \"system\": \"http://terminology.hl7.org/CodeSystem/v2-0276\",\n        \"code\": \"ROUTINE\"\n      }\n    ]\n  },\n  \"start\": \"2023-09-15T09:00:00Z\",\n  \"end\": \"2023-09-15T09:30:00Z\",\n  \"participant\": [\n    {\n      \"actor\": {\n        \"reference\": \"Patient/patient-uuid-123\"\n      },\n      \"required\": \"required\",\n      \"status\": \"accepted\"\n    },\n    {\n      \"actor\": {\n        \"reference\": \"Practitioner/doc-uuid-456\"\n      },\n      \"required\": \"required\",\n      \"status\": \"accepted\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/appointments/",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "appointments"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Real-time Availability",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/appointments/availability?practitioner=doc-uuid-456&date=2023-09-15&duration=30&serviceType=routine",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "appointments",
+                "availability"
+              ],
+              "query": [
+                {
+                  "key": "practitioner",
+                  "value": "doc-uuid-456"
+                },
+                {
+                  "key": "date",
+                  "value": "2023-09-15"
+                },
+                {
+                  "key": "duration",
+                  "value": "30"
+                },
+                {
+                  "key": "serviceType",
+                  "value": "routine"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Waitlist Management",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"patientId\": \"patient-uuid-123\",\n  \"preferredDates\": [\n    \"2023-09-15\",\n    \"2023-09-16\"\n  ],\n  \"preferredTimes\": [\"morning\", \"afternoon\"],\n  \"priority\": \"routine\",\n  \"notificationPreferences\": {\n    \"email\": true,\n    \"sms\": true,\n    \"advanceNotice\": \"24h\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/appointments/{{appointmentId}}/waitlist",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "appointments",
+                "{{appointmentId}}",
+                "waitlist"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "User Auth Service",
+      "item": [
+        {
+          "name": "User Login",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"john.doe@example.com\",\n  \"password\": \"SecurePass123!\",\n  \"mfaCode\": \"123456\",\n  \"deviceInfo\": {\n    \"deviceId\": \"device-uuid-123\",\n    \"userAgent\": \"Mozilla/5.0...\",\n    \"ipAddress\": \"192.168.1.100\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          }
+        },
+        {
+          "name": "User Registration",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"john.doe@example.com\",\n  \"password\": \"SecurePass123!\",\n  \"confirmPassword\": \"SecurePass123!\",\n  \"profile\": {\n    \"firstName\": \"John\",\n    \"lastName\": \"Doe\",\n    \"phone\": \"555-123-4567\",\n    \"dateOfBirth\": \"1980-01-15\"\n  },\n  \"acceptTerms\": true,\n  \"verificationMethod\": \"email\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/register",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "register"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Password Reset",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"john.doe@example.com\",\n  \"resetMethod\": \"email\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/password-reset",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "password-reset"
+              ]
+            }
+          }
+        },
+        {
+          "name": "MFA Setup",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"method\": \"totp\",\n  \"deviceName\": \"iPhone 12\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/mfa/setup",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "mfa",
+                "setup"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Role Management Service",
+      "item": [
+        {
+          "name": "Role Assignment",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": \"user-uuid-123\",\n  \"roles\": [\"doctor\", \"department_head\"],\n  \"effectiveDate\": \"2023-09-01T00:00:00Z\",\n  \"expiryDate\": \"2024-09-01T00:00:00Z\",\n  \"assignedBy\": \"admin-uuid-456\",\n  \"reason\": \"Promotion to department head\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/roles/assign",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "roles",
+                "assign"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Permission Validation",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"userId\": \"user-uuid-123\",\n  \"resource\": \"Patient/patient-uuid-456\",\n  \"action\": \"read\",\n  \"context\": {\n    \"facility\": \"facility-uuid-789\",\n    \"department\": \"cardiology\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/roles/validate",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "roles",
+                "validate"
+              ]
+            }
+          }
+        },
+        {
+          "name": "ABAC Evaluation",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"subject\": {\n    \"userId\": \"user-uuid-123\",\n    \"roles\": [\"doctor\"],\n    \"department\": \"cardiology\",\n    \"facility\": \"facility-uuid-789\"\n  },\n  \"resource\": {\n    \"type\": \"Patient\",\n    \"id\": \"patient-uuid-456\",\n    \"attributes\": {\n      \"facility\": \"facility-uuid-789\",\n      \"department\": \"cardiology\"\n    }\n  },\n  \"action\": \"read\",\n  \"environment\": {\n    \"time\": \"2023-09-01T14:30:00Z\",\n    \"location\": \"clinic\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/roles/abac/evaluate",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "roles",
+                "abac",
+                "evaluate"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Telemedicine Service",
+      "item": [
+        {
+          "name": "Session Creation",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"appointmentId\": \"appt-uuid-789\",\n  \"participants\": [\n    {\n      \"userId\": \"patient-uuid-123\",\n      \"role\": \"patient\"\n    },\n    {\n      \"userId\": \"doc-uuid-456\",\n      \"role\": \"provider\"\n    }\n  ],\n  \"sessionType\": \"video_consultation\",\n  \"scheduledStart\": \"2023-09-15T09:00:00Z\",\n  \"estimatedDuration\": 30\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/telemedicine/sessions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "telemedicine",
+                "sessions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Consent Management",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"sessionId\": \"session-uuid-101\",\n  \"userId\": \"patient-uuid-123\",\n  \"consentType\": \"video_recording\",\n  \"granted\": true,\n  \"timestamp\": \"2023-09-15T08:55:00Z\",\n  \"ipAddress\": \"192.168.1.100\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/telemedicine/consent",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "telemedicine",
+                "consent"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Quality Monitoring",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/telemedicine/sessions/{{sessionId}}/metrics",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "telemedicine",
+                "sessions",
+                "{{sessionId}}",
+                "metrics"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Notification Service",
+      "item": [
+        {
+          "name": "Send Notification",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"recipientId\": \"user-uuid-123\",\n  \"channels\": [\"email\", \"sms\"],\n  \"template\": \"appointment_reminder\",\n  \"data\": {\n    \"appointmentDate\": \"2023-09-15T09:00:00Z\",\n    \"doctorName\": \"Dr. Jane Smith\",\n    \"location\": \"Room 101, Main Building\"\n  },\n  \"scheduledAt\": \"2023-09-14T20:00:00Z\",\n  \"priority\": \"normal\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/notifications/send",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "notifications",
+                "send"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Template Management",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"appointment_reminder\",\n  \"channels\": {\n    \"email\": {\n      \"subject\": \"Appointment Reminder - {{appointmentDate}}\",\n      \"body\": \"Dear {{patientName}}, you have an appointment with {{doctorName}} on {{appointmentDate}}.\"\n    },\n    \"sms\": {\n      \"body\": \"Reminder: Appointment with {{doctorName}} on {{appointmentDate}}. Reply STOP to opt out.\"\n    }\n  },\n  \"variables\": [\"patientName\", \"doctorName\", \"appointmentDate\"]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/notifications/templates",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "notifications",
+                "templates"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Bulk Notification",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"campaignName\": \"flu_shot_reminder\",\n  \"template\": \"vaccination_reminder\",\n  \"recipients\": [\n    {\n      \"userId\": \"user-uuid-123\",\n      \"data\": {\n        \"patientName\": \"John Doe\"\n      }\n    },\n    {\n      \"userId\": \"user-uuid-456\",\n      \"data\": {\n        \"patientName\": \"Jane Smith\"\n      }\n    }\n  ],\n  \"channels\": [\"email\"],\n  \"scheduledAt\": \"2023-09-20T10:00:00Z\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/notifications/bulk",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "notifications",
+                "bulk"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Analytics Service",
+      "item": [
+        {
+          "name": "Risk Scoring",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"patientId\": \"patient-uuid-123\",\n  \"riskType\": \"diabetes\",\n  \"factors\": [\n    {\n      \"type\": \"observation\",\n      \"code\": \"33747-0\",\n      \"value\": 95,\n      \"unit\": \"mg/dL\"\n    },\n    {\n      \"type\": \"demographic\",\n      \"age\": 43,\n      \"gender\": \"male\",\n      \"bmi\": 28.5\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/analytics/risk-score",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "analytics",
+                "risk-score"
+              ]
+            }
+          }
+        },
+        {
+          "name": "ML Model Training",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"trainingJob\": {\n    \"modelName\": \"diabetes_risk_classifier\",\n    \"modelType\": \"classification\",\n    \"algorithm\": \"random_forest\",\n    \"targetVariable\": \"diabetes_diagnosis\",\n    \"features\": [\n      {\n        \"name\": \"age\",\n        \"type\": \"numeric\",\n        \"source\": \"Patient.birthDate\",\n        \"preprocessing\": \"age_calculation\"\n      },\n      {\n        \"name\": \"bmi\",\n        \"type\": \"numeric\",\n        \"source\": \"Observation\",\n        \"loincCode\": \"39156-5\",\n        \"preprocessing\": \"outlier_removal\"\n      },\n      {\n        \"name\": \"glucose_level\",\n        \"type\": \"numeric\",\n        \"source\": \"Observation\",\n        \"loincCode\": \"2339-0\",\n        \"aggregation\": \"latest_value\"\n      },\n      {\n        \"name\": \"family_history\",\n        \"type\": \"categorical\",\n        \"source\": \"FamilyMemberHistory\",\n        \"valueSet\": \"diabetes_conditions\"\n      }\n    ],\n    \"trainingParameters\": {\n      \"dataRange\": {\n        \"start\": \"2020-01-01\",\n        \"end\": \"2023-08-31\"\n      },\n      \"validationSplit\": 0.2,\n      \"testSplit\": 0.1,\n      \"hyperparameters\": {\n        \"n_estimators\": 100,\n        \"max_depth\": 10,\n        \"min_samples_split\": 5,\n        \"random_state\": 42\n      },\n      \"crossValidation\": {\n        \"folds\": 5,\n        \"stratified\": true\n      }\n    },\n    \"dataPrivacy\": {\n      \"anonymization\": \"k_anonymity\",\n      \"k_value\": 5,\n      \"excludePII\": true,\n      \"auditRequired\": true\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/analytics/ml/models/train",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "analytics",
+                "ml",
+                "models",
+                "train"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Personalized Clinical Alerts",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"patientId\": \"patient-uuid-123\",\n  \"modelId\": \"model-uuid-456\",\n  \"alertConfiguration\": {\n    \"riskThreshold\": 0.75,\n    \"alertTypes\": [\"high_risk\", \"trend_deterioration\"],\n    \"timeHorizon\": \"P30D\",\n    \"updateFrequency\": \"daily\"\n  },\n  \"contextualFactors\": [\n    {\n      \"type\": \"recent_observations\",\n      \"lookbackPeriod\": \"P7D\",\n      \"weight\": 0.4\n    },\n    {\n      \"type\": \"medication_adherence\",\n      \"source\": \"MedicationStatement\",\n      \"weight\": 0.3\n    },\n    {\n      \"type\": \"lifestyle_factors\",\n      \"source\": \"Observation\",\n      \"categories\": [\"exercise\", \"diet\", \"smoking\"],\n      \"weight\": 0.3\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/analytics/ml/alerts/personalized",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "analytics",
+                "ml",
+                "alerts",
+                "personalized"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Model Versioning",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"versionInfo\": {\n    \"version\": \"2.1.0\",\n    \"description\": \"Improved diabetes risk model with additional lifestyle factors\",\n    \"trainingJobId\": \"job-uuid-123\",\n    \"baselineModel\": \"model-uuid-456-v2.0.0\"\n  },\n  \"performanceMetrics\": {\n    \"accuracy\": 0.89,\n    \"precision\": 0.87,\n    \"recall\": 0.91,\n    \"f1Score\": 0.89,\n    \"auc\": 0.94,\n    \"crossValidationScore\": 0.88\n  },\n  \"modelArtifacts\": {\n    \"modelFile\": \"diabetes_rf_v2.1.0.pkl\",\n    \"featureImportance\": \"feature_importance_v2.1.0.json\",\n    \"preprocessor\": \"preprocessor_v2.1.0.pkl\",\n    \"metadata\": \"model_metadata_v2.1.0.json\"\n  },\n  \"deploymentConfig\": {\n    \"environment\": \"production\",\n    \"rolloutStrategy\": \"blue_green\",\n    \"canaryPercentage\": 10,\n    \"monitoringPeriod\": \"P7D\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/analytics/ml/models/{{modelId}}/versions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "analytics",
+                "ml",
+                "models",
+                "{{modelId}}",
+                "versions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Healthcare Trend Analysis",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/analytics/analytics/trends?metric=readmission_rate,infection_rate,mortality_rate&timeRange=P1Y&granularity=monthly&demographics=age,gender,department&facility=facility-uuid-001",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "analytics",
+                "analytics",
+                "trends"
+              ],
+              "query": [
+                {
+                  "key": "metric",
+                  "value": "readmission_rate,infection_rate,mortality_rate"
+                },
+                {
+                  "key": "timeRange",
+                  "value": "P1Y"
+                },
+                {
+                  "key": "granularity",
+                  "value": "monthly"
+                },
+                {
+                  "key": "demographics",
+                  "value": "age,gender,department"
+                },
+                {
+                  "key": "facility",
+                  "value": "facility-uuid-001"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "FHIR Prediction Linking",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"predictionId\": \"prediction-uuid-123\",\n  \"patientId\": \"patient-uuid-456\",\n  \"modelId\": \"model-uuid-789\",\n  \"fhirMapping\": {\n    \"primaryResource\": {\n      \"resourceType\": \"RiskAssessment\",\n      \"method\": {\n        \"coding\": [\n          {\n            \"system\": \"http://example.org/ml-models\",\n            \"code\": \"diabetes_risk_rf_v2.1.0\",\n            \"display\": \"Diabetes Risk Random Forest v2.1.0\"\n          }\n        ]\n      },\n      \"prediction\": [\n        {\n          \"outcome\": {\n            \"coding\": [\n              {\n                \"system\": \"http://snomed.info/sct\",\n                \"code\": \"44054006\",\n                \"display\": \"Type 2 diabetes mellitus\"\n              }\n            ]\n          },\n          \"probabilityDecimal\": 0.82,\n          \"whenRange\": {\n            \"low\": {\n              \"value\": 30,\n              \"unit\": \"d\"\n            },\n            \"high\": {\n              \"value\": 90,\n              \"unit\": \"d\"\n            }\n          }\n        }\n      ]\n    },\n    \"supportingResources\": [\n      {\n        \"resourceType\": \"DetectedIssue\",\n        \"status\": \"final\",\n        \"category\": {\n          \"coding\": [\n            {\n              \"system\": \"http://terminology.hl7.org/CodeSystem/v3-ActCode\",\n              \"code\": \"CAUTION\"\n            }\n          ]\n        },\n        \"detail\": \"High risk for developing diabetes based on current health indicators\"\n      }\n    ]\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/analytics/ml/predictions/link-fhir",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "analytics",
+                "ml",
+                "predictions",
+                "link-fhir"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Audit Logging Service",
+      "item": [
+        {
+          "name": "Log Access Event",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"eventType\": \"data_access\",\n  \"userId\": \"user-uuid-123\",\n  \"resourceType\": \"Patient\",\n  \"resourceId\": \"patient-uuid-456\",\n  \"action\": \"read\",\n  \"timestamp\": \"2023-09-01T12:30:45Z\",\n  \"sessionId\": \"session-uuid-789\",\n  \"ipAddress\": \"192.168.1.100\",\n  \"userAgent\": \"Mozilla/5.0...\",\n  \"metadata\": {\n    \"reason\": \"Patient consultation\",\n    \"department\": \"cardiology\",\n    \"facility\": \"facility-uuid-001\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/audit/events",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "audit",
+                "events"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Export Audit Logs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/audit/export?startDate=2023-08-01&endDate=2023-09-01&userId=user-uuid-123&resourceType=Patient&format=csv",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "audit",
+                "export"
+              ],
+              "query": [
+                {
+                  "key": "startDate",
+                  "value": "2023-08-01"
+                },
+                {
+                  "key": "endDate",
+                  "value": "2023-09-01"
+                },
+                {
+                  "key": "userId",
+                  "value": "user-uuid-123"
+                },
+                {
+                  "key": "resourceType",
+                  "value": "Patient"
+                },
+                {
+                  "key": "format",
+                  "value": "csv"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anomaly Detection",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/audit/anomalies",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "audit",
+                "anomalies"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "FHIR API Gateway",
+      "item": [
+        {
+          "name": "Capability Statement",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/fhir+json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/R4/metadata",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "R4",
+                "metadata"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get Patient",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/fhir+json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/fhir/R4/Patient/patient-uuid-123",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "R4",
+                "Patient",
+                "patient-uuid-123"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Batch Operations",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Bundle\",\n  \"type\": \"batch\",\n  \"entry\": [\n    {\n      \"request\": {\n        \"method\": \"GET\",\n        \"url\": \"Patient/patient-uuid-123\"\n      }\n    },\n    {\n      \"request\": {\n        \"method\": \"GET\",\n        \"url\": \"Observation?patient=patient-uuid-123\"\n      }\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/fhir/R4/",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "fhir",
+                "R4"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/fhir_portal/README.md
+++ b/fhir_portal/README.md
@@ -1,0 +1,71 @@
+# FHIR Patient Portal (Django)
+
+This Django project provides stubbed endpoints that mirror the "FHIR Patient Portal - Complete API Specifications". Each endpoint returns sample payloads from the specification so that frontend or integration teams can prototype against realistic responses while the business logic is still under development.
+
+## Project Layout
+
+```
+fhir_portal/
+  manage.py
+  fhir_portal/
+    settings.py
+    urls.py
+  services/
+    urls.py
+    fhir_urls.py
+    views/
+      *.py
+```
+
+* `services/urls.py` mounts each domain-specific router under `/api/v1/`.
+* `services/fhir_urls.py` provides the `/fhir/R4` gateway routes.
+* `services/views/` contains dedicated modules for HL7 parsing, patient management, observations, appointments, authentication, roles, telemedicine, notifications, analytics, and audit logging.
+
+## Running Locally
+
+### Prerequisites
+
+* Python 3.11+
+* MySQL 8.0+
+
+Create a database and user for the portal:
+
+```sql
+CREATE DATABASE fhir_portal CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER 'fhir_user'@'%' IDENTIFIED BY 'fhir_password';
+GRANT ALL PRIVILEGES ON fhir_portal.* TO 'fhir_user'@'%';
+FLUSH PRIVILEGES;
+```
+
+### Environment configuration
+
+The Django settings read the connection parameters from the following environment variables, defaulting to the values shown above:
+
+* `MYSQL_DATABASE`
+* `MYSQL_USER`
+* `MYSQL_PASSWORD`
+* `MYSQL_HOST`
+* `MYSQL_PORT`
+
+### Run locally
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+export MYSQL_HOST=127.0.0.1  # adjust as needed
+python manage.py migrate
+python manage.py runserver 0.0.0.0:8000
+```
+
+The project intentionally uses static sample responses to document the contract. Replace the response bodies with production logic as services mature.
+
+### Run with Docker Compose
+
+This repository includes a `docker-compose.yml` that provisions both the Django application and a MySQL 8 instance with the same defaults as the development settings. To start everything:
+
+```bash
+docker-compose up --build
+```
+
+The first run builds the application image, runs database migrations, and then serves the API at [http://localhost:8000](http://localhost:8000). MySQL data persists in the `mysql-data` Docker volume so the database keeps its state across restarts. Override the default credentials by setting environment variables in a `.env` file alongside the compose file if needed.

--- a/fhir_portal/fhir_portal/asgi.py
+++ b/fhir_portal/fhir_portal/asgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fhir_portal.settings')
+application = get_asgi_application()

--- a/fhir_portal/fhir_portal/settings.py
+++ b/fhir_portal/fhir_portal/settings.py
@@ -1,0 +1,68 @@
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+SECRET_KEY = 'dummy-secret-key-for-fhir-portal'
+DEBUG = True
+ALLOWED_HOSTS = ['*']
+
+INSTALLED_APPS = [
+    'django.contrib.contenttypes',
+    'django.contrib.staticfiles',
+    'django.contrib.auth',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'rest_framework',
+    'services',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
+ROOT_URLCONF = 'fhir_portal.urls'
+
+TEMPLATES = []
+
+WSGI_APPLICATION = 'fhir_portal.wsgi.application'
+ASGI_APPLICATION = 'fhir_portal.asgi.application'
+
+if os.environ.get('USE_SQLITE_FOR_TESTS'):
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'test_db.sqlite3',
+        }
+    }
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': os.environ.get('MYSQL_DATABASE', 'fhir_portal'),
+            'USER': os.environ.get('MYSQL_USER', 'fhir_user'),
+            'PASSWORD': os.environ.get('MYSQL_PASSWORD', 'fhir_password'),
+            'HOST': os.environ.get('MYSQL_HOST', '127.0.0.1'),
+            'PORT': os.environ.get('MYSQL_PORT', '3306'),
+            'OPTIONS': {
+                'charset': 'utf8mb4',
+                'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+            },
+        }
+    }
+
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = 'static/'
+
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': ['rest_framework.renderers.JSONRenderer'],
+    'DEFAULT_PARSER_CLASSES': ['rest_framework.parsers.JSONParser'],
+}

--- a/fhir_portal/fhir_portal/urls.py
+++ b/fhir_portal/fhir_portal/urls.py
@@ -1,0 +1,6 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path('api/v1/', include('services.urls')),
+    path('fhir/R4/', include('services.fhir_urls')),
+]

--- a/fhir_portal/fhir_portal/wsgi.py
+++ b/fhir_portal/fhir_portal/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fhir_portal.settings')
+application = get_wsgi_application()

--- a/fhir_portal/manage.py
+++ b/fhir_portal/manage.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import os
+import sys
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fhir_portal.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+if __name__ == '__main__':
+    main()

--- a/fhir_portal/requirements.txt
+++ b/fhir_portal/requirements.txt
@@ -1,0 +1,3 @@
+Django>=4.2,<5.0
+djangorestframework>=3.14,<4.0
+mysqlclient>=2.1,<3.0

--- a/fhir_portal/services/fhir_urls.py
+++ b/fhir_portal/services/fhir_urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import fhir_gateway
+
+urlpatterns = [
+    path('metadata', fhir_gateway.get_capability_statement),
+    path('Patient/<str:patient_id>', fhir_gateway.get_patient),
+    path('', fhir_gateway.batch_operations),
+]

--- a/fhir_portal/services/sample_utils.py
+++ b/fhir_portal/services/sample_utils.py
@@ -1,0 +1,57 @@
+"""Utility helpers for generating dynamic sample responses.
+
+These helpers keep the illustrative payloads aligned with the API
+specification while avoiding brittle hard-coded identifiers or timestamps.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping, MutableMapping
+from uuid import uuid4
+
+from django.utils import timezone
+
+
+def isoformat_now() -> str:
+    """Return the current timestamp in ISO 8601 format with UTC suffix."""
+
+    value = timezone.now().isoformat()
+    return value.replace("+00:00", "Z") if value.endswith("+00:00") else value
+
+
+def generate_identifier(prefix: str, *, override: str | None = None) -> str:
+    """Create a deterministic looking identifier for sample responses."""
+
+    return override or f"{prefix}-{uuid4()}"
+
+
+def deep_merge(base: Mapping[str, Any], overrides: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Recursively merge mapping values.
+
+    ``overrides`` wins over ``base`` and nested dictionaries are merged to allow
+    callers to provide partial payloads while keeping sample defaults.
+    """
+
+    result: dict[str, Any] = deepcopy(base)
+    if not overrides:
+        return result
+
+    for key, value in overrides.items():
+        if (
+            isinstance(value, Mapping)
+            and key in result
+            and isinstance(result[key], MutableMapping)
+        ):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = deepcopy(value)
+    return result
+
+
+def ensure_list(value: Any, default: list[Any]) -> list[Any]:
+    """Return ``value`` if it is a non-empty list, otherwise ``default``."""
+
+    if isinstance(value, list) and value:
+        return value
+    return deepcopy(default)

--- a/fhir_portal/services/tests/test_sample_utils.py
+++ b/fhir_portal/services/tests/test_sample_utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from services.sample_utils import deep_merge, ensure_list, generate_identifier, isoformat_now
+
+
+class IsoformatNowTests(SimpleTestCase):
+    def test_returns_utc_timestamp_with_z_suffix(self) -> None:
+        fixed = timezone.datetime(2023, 9, 1, 12, 30, 45, tzinfo=timezone.utc)
+        with patch("services.sample_utils.timezone.now", return_value=fixed):
+            self.assertEqual(isoformat_now(), "2023-09-01T12:30:45Z")
+
+
+class GenerateIdentifierTests(SimpleTestCase):
+    def test_uses_override_when_provided(self) -> None:
+        self.assertEqual(generate_identifier("patient", override="custom-id"), "custom-id")
+
+    def test_generates_unique_identifier_with_prefix(self) -> None:
+        identifier = generate_identifier("patient")
+        self.assertTrue(identifier.startswith("patient-"))
+
+
+class DeepMergeTests(SimpleTestCase):
+    def test_merges_nested_mappings_without_mutating_base(self) -> None:
+        base = {"nested": {"value": 1}, "keep": 2}
+        overrides = {"nested": {"extra": 3}}
+
+        result = deep_merge(base, overrides)
+
+        self.assertEqual(result["nested"], {"value": 1, "extra": 3})
+        self.assertEqual(result["keep"], 2)
+        # Ensure the base mapping was not modified in place
+        self.assertEqual(base, {"nested": {"value": 1}, "keep": 2})
+
+
+class EnsureListTests(SimpleTestCase):
+    def test_returns_existing_non_empty_list(self) -> None:
+        values = [1]
+        self.assertIs(ensure_list(values, [2]), values)
+
+    def test_returns_copy_of_default_for_empty_or_invalid_values(self) -> None:
+        default = ["fallback"]
+        result = ensure_list([], default)
+
+        self.assertEqual(result, default)
+        self.assertIsNot(result, default)
+
+        result_none = ensure_list(None, default)
+        self.assertEqual(result_none, default)
+        self.assertIsNot(result_none, default)

--- a/fhir_portal/services/tests/test_views.py
+++ b/fhir_portal/services/tests/test_views.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from django.test import SimpleTestCase, override_settings
+from rest_framework.test import APIClient
+
+
+SQLITE_DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+
+@override_settings(DATABASES=SQLITE_DATABASES)
+class HL7ParserViewTests(SimpleTestCase):
+    client_class = APIClient
+
+    def test_ingest_merges_payload_with_defaults(self) -> None:
+        payload = {
+            "status": "custom-status",
+            "fhirResources": [
+                {
+                    "identifier": [{"value": "MRN12345"}],
+                    "name": [{"family": "Doe", "given": ["John"]}],
+                }
+            ],
+        }
+
+        response = self.client.post("/api/v1/hl7-parser/ingest", payload, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["status"], "custom-status")
+        self.assertEqual(
+            response.data["fhirResources"][0]["identifier"], [{"value": "MRN12345"}]
+        )
+        self.assertIn("messageId", response.data)
+        self.assertIn("timestamp", response.data)
+
+
+@override_settings(DATABASES=SQLITE_DATABASES)
+class PatientViewTests(SimpleTestCase):
+    client_class = APIClient
+
+    def test_registration_populates_default_identifiers_and_names(self) -> None:
+        payload = {
+            "identifier": [],
+            "name": [],
+            "gender": "male",
+            "birthDate": "1980-01-15",
+        }
+
+        response = self.client.post("/api/v1/patients/", payload, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["gender"], "male")
+        self.assertEqual(response.data["identifier"][0]["value"], "MRN-SAMPLE")
+        self.assertEqual(response.data["name"][0]["family"], "Sample")
+        self.assertIn("meta", response.data)
+        self.assertIn("lastUpdated", response.data["meta"])
+
+
+@override_settings(DATABASES=SQLITE_DATABASES)
+class ObservationViewTests(SimpleTestCase):
+    client_class = APIClient
+
+    def test_lab_results_default_entry_contains_location(self) -> None:
+        response = self.client.post("/api/v1/observations/lab-results", {}, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["resourceType"], "Bundle")
+        self.assertTrue(response.data["entry"])
+        entry = response.data["entry"][0]
+        self.assertIn("response", entry)
+        self.assertIn("Observation/", entry["response"]["location"])
+
+
+@override_settings(DATABASES=SQLITE_DATABASES)
+class KafkaViewTests(SimpleTestCase):
+    client_class = APIClient
+
+    def test_event_schema_returns_compliance_metadata(self) -> None:
+        response = self.client.get("/api/v1/kafka/events/schema")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("compliance", response.data)
+        self.assertEqual(response.data["eventType"], "patient.registered.v1")
+
+    def test_configuration_supports_section_filter(self) -> None:
+        response = self.client.get("/api/v1/kafka/config", {"section": "topics"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("patient.lifecycle.v1", response.data)
+
+    def test_governance_includes_retry_policy(self) -> None:
+        response = self.client.get("/api/v1/kafka/governance")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("retryPolicy", response.data)

--- a/fhir_portal/services/urls.py
+++ b/fhir_portal/services/urls.py
@@ -1,0 +1,28 @@
+from django.urls import include, path
+from .views import (
+    analytics,
+    audit,
+    auth,
+    appointments,
+    hl7,
+    kafka,
+    notifications,
+    observations,
+    patients,
+    roles,
+    telemedicine,
+)
+
+urlpatterns = [
+    path('hl7-parser/', include((hl7.urlpatterns, 'hl7'), namespace='hl7-parser')),
+    path('patients/', include((patients.urlpatterns, 'patients'), namespace='patients')),
+    path('observations/', include((observations.urlpatterns, 'observations'), namespace='observations')),
+    path('appointments/', include((appointments.urlpatterns, 'appointments'), namespace='appointments')),
+    path('auth/', include((auth.urlpatterns, 'auth'), namespace='auth')),
+    path('roles/', include((roles.urlpatterns, 'roles'), namespace='roles')),
+    path('telemedicine/', include((telemedicine.urlpatterns, 'telemedicine'), namespace='telemedicine')),
+    path('notifications/', include((notifications.urlpatterns, 'notifications'), namespace='notifications')),
+    path('analytics/', include((analytics.urlpatterns, 'analytics'), namespace='analytics')),
+    path('audit/', include((audit.urlpatterns, 'audit'), namespace='audit')),
+    path('kafka/', include((kafka.urlpatterns, 'kafka'), namespace='kafka')),
+]

--- a/fhir_portal/services/views/__init__.py
+++ b/fhir_portal/services/views/__init__.py
@@ -1,0 +1,14 @@
+from . import (
+    analytics,
+    audit,
+    auth,
+    appointments,
+    fhir_gateway,
+    hl7,
+    kafka,
+    notifications,
+    observations,
+    patients,
+    roles,
+    telemedicine,
+)

--- a/fhir_portal/services/views/analytics.py
+++ b/fhir_portal/services/views/analytics.py
@@ -1,0 +1,191 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import deep_merge, ensure_list, generate_identifier, isoformat_now
+
+
+@api_view(['POST'])
+def risk_score(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'patientId': payload.get('patientId', generate_identifier('patient')),
+        'riskType': payload.get('riskType', 'diabetes'),
+        'score': float(payload.get('score', 0.75)),
+        'level': payload.get('level', 'high'),
+        'confidence': float(payload.get('confidence', 0.89)),
+        'factors': ensure_list(payload.get('factors'), []),
+        'recommendations': ensure_list(
+            payload.get('recommendations'), ['Regular monitoring']
+        ),
+        'calculatedAt': payload.get('calculatedAt', isoformat_now()),
+    }
+    return Response(template)
+
+
+@api_view(['POST'])
+def train_model(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    dataset_info = deep_merge(
+        {
+            'totalRecords': 0,
+            'trainingRecords': 0,
+            'validationRecords': 0,
+            'testRecords': 0,
+            'featureCount': 0,
+            'classDistribution': {},
+        },
+        payload.get('datasetInfo', {}),
+    )
+    template = {
+        'trainingJobId': generate_identifier('job', override=payload.get('trainingJobId')),
+        'status': payload.get('status', 'running'),
+        'estimatedCompletion': payload.get('estimatedCompletion', isoformat_now()),
+        'datasetInfo': dataset_info,
+        'progress': deep_merge(
+            {'currentStep': 'pending', 'completionPercent': 0, 'estimatedTimeRemaining': None},
+            payload.get('progress', {}),
+        ),
+    }
+    return Response(template)
+
+
+@api_view(['POST'])
+def personalized_alerts(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'alertId': generate_identifier('alert', override=payload.get('alertId')),
+        'patientId': payload.get('patientId', generate_identifier('patient')),
+        'riskAssessment': deep_merge(
+            {
+                'overallRisk': 0.0,
+                'riskLevel': 'low',
+                'confidence': 0.0,
+                'prediction': {
+                    'condition': 'unspecified',
+                    'probability': 0.0,
+                    'timeHorizon': 'P0D',
+                },
+            },
+            payload.get('riskAssessment', {}),
+        ),
+        'contributingFactors': ensure_list(payload.get('contributingFactors'), []),
+        'recommendations': ensure_list(payload.get('recommendations'), []),
+        'fhirResources': ensure_list(payload.get('fhirResources'), []),
+    }
+    return Response(template)
+
+
+@api_view(['POST'])
+def model_version(request, model_id: str):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'modelVersionId': generate_identifier('model-version', override=payload.get('modelVersionId')),
+        'status': payload.get('status', 'deployed'),
+        'deploymentTimestamp': payload.get('deploymentTimestamp', isoformat_now()),
+        'performanceComparison': deep_merge(
+            {
+                'previousVersion': {},
+                'improvement': {},
+            },
+            payload.get('performanceComparison', {}),
+        ),
+        'productionMetrics': deep_merge(
+            {'predictionLatency': None, 'throughput': None, 'errorRate': None},
+            payload.get('productionMetrics', {}),
+        ),
+        'modelId': model_id,
+    }
+    return Response(template)
+
+
+@api_view(['GET'])
+def healthcare_trends(request):
+    query = request.query_params
+    time_range = {
+        'start': query.get('start', isoformat_now()),
+        'end': query.get('end', isoformat_now()),
+    }
+    metrics = query.getlist('metric')
+    if metrics:
+        trends = [
+            {
+                'metric': metric,
+                'overall': {
+                    'currentValue': float(query.get(f'{metric}.current', 0.0)),
+                    'previousPeriod': float(query.get(f'{metric}.previous', 0.0)),
+                    'changePercent': float(query.get(f'{metric}.changePercent', 0.0)),
+                    'trend': query.get(f'{metric}.trend', 'stable'),
+                    'significance': query.get(f'{metric}.significance', 'n/a'),
+                },
+                'byDemographics': [],
+                'timeSeriesData': [],
+            }
+            for metric in metrics
+        ]
+    else:
+        trends = [
+            {
+                'metric': 'readmission_rate',
+                'overall': {
+                    'currentValue': 0.0,
+                    'previousPeriod': 0.0,
+                    'changePercent': 0.0,
+                    'trend': 'stable',
+                    'significance': 'n/a',
+                },
+                'byDemographics': [],
+                'timeSeriesData': [],
+            }
+        ]
+    response = {
+        'analysisId': query.get('analysisId', generate_identifier('trend-analysis')),
+        'timeRange': time_range,
+        'trends': trends,
+        'correlations': ensure_list([], []),
+        'anomalies': ensure_list([], []),
+    }
+    return Response(response)
+
+
+@api_view(['POST'])
+def link_fhir(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    default_resource = {
+        'resourceType': 'RiskAssessment',
+        'id': generate_identifier('risk-assessment'),
+        'status': 'final',
+        'subject': {'reference': f"Patient/{payload.get('patientId', generate_identifier('patient'))}"},
+        'performer': {'reference': 'Device/ml-model-device'},
+        'prediction': [
+            {
+                'outcome': {'coding': []},
+                'probabilityDecimal': 0.0,
+            }
+        ],
+    }
+    template = {
+        'linkingId': generate_identifier('fhir-link', override=payload.get('linkingId')),
+        'fhirResources': ensure_list(payload.get('fhirResources'), [default_resource]),
+        'auditTrail': deep_merge(
+            {
+                'createdBy': 'ml-system',
+                'createdAt': isoformat_now(),
+                'modelVersion': payload.get('modelId', '1.0.0'),
+                'inputFeatures': payload.get('inputFeatures', 0),
+                'confidence': payload.get('confidence', 0.0),
+            },
+            payload.get('auditTrail', {}),
+        ),
+    }
+    return Response(template)
+
+
+urlpatterns = [
+    path('risk-score', risk_score, name='risk-score'),
+    path('ml/models/train', train_model, name='train-model'),
+    path('ml/alerts/personalized', personalized_alerts, name='personalized-alerts'),
+    path('ml/models/<str:model_id>/versions', model_version, name='model-version'),
+    path('analytics/trends', healthcare_trends, name='trends'),
+    path('ml/predictions/link-fhir', link_fhir, name='link-fhir'),
+]

--- a/fhir_portal/services/views/appointments.py
+++ b/fhir_portal/services/views/appointments.py
@@ -1,0 +1,73 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import deep_merge, ensure_list, generate_identifier, isoformat_now
+
+
+def _appointment_template(payload: dict | None = None) -> dict:
+    payload = payload or {}
+    return {
+        'resourceType': 'Appointment',
+        'id': generate_identifier('appt', override=payload.get('id')),
+        'meta': {
+            'versionId': payload.get('meta', {}).get('versionId', '1'),
+            'lastUpdated': isoformat_now(),
+        },
+        'status': payload.get('status', 'booked'),
+        'start': payload.get('start', isoformat_now()),
+        'end': payload.get('end', isoformat_now()),
+        'confirmationCode': payload.get('confirmationCode', generate_identifier('conf')),
+        'participant': ensure_list(payload.get('participant'), []),
+    }
+
+
+@api_view(['POST'])
+def book(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    return Response(deep_merge(_appointment_template(payload), payload))
+
+
+@api_view(['GET'])
+def availability(request):
+    slots = ensure_list(
+        None,
+        [
+            {
+                'start': isoformat_now(),
+                'end': isoformat_now(),
+                'type': 'available',
+            }
+        ],
+    )
+    return Response(
+        {
+            'date': request.query_params.get('date', isoformat_now().split('T')[0]),
+            'practitioner': request.query_params.get(
+                'practitioner', generate_identifier('practitioner')
+            ),
+            'availableSlots': slots,
+        }
+    )
+
+
+@api_view(['POST'])
+def waitlist(request, appointment_id: str):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'appointmentId': appointment_id,
+        'status': payload.get('status', 'added'),
+        'priority': payload.get('priority', 'routine'),
+        'notificationPreferences': payload.get(
+            'notificationPreferences',
+            {'email': True, 'sms': True, 'advanceNotice': '24h'},
+        ),
+    }
+    return Response(template)
+
+
+urlpatterns = [
+    path('', book, name='book'),
+    path('availability', availability, name='availability'),
+    path('<str:appointment_id>/waitlist', waitlist, name='waitlist'),
+]

--- a/fhir_portal/services/views/audit.py
+++ b/fhir_portal/services/views/audit.py
@@ -1,0 +1,59 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import ensure_list, generate_identifier, isoformat_now
+
+
+@api_view(['POST'])
+def log_event(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'auditId': generate_identifier('audit', override=payload.get('auditId')),
+        'status': payload.get('status', 'logged'),
+        'timestamp': payload.get('timestamp', isoformat_now()),
+        'immutableHash': payload.get('immutableHash', 'sha256:placeholder'),
+    }
+    return Response(template)
+
+
+@api_view(['GET'])
+def export_logs(request):
+    response = {
+        'exportId': request.query_params.get('exportId', generate_identifier('export')),
+        'status': request.query_params.get('status', 'processing'),
+        'format': request.query_params.get('format', 'csv'),
+        'downloadUrl': request.query_params.get(
+            'downloadUrl', f"/api/v1/audit/exports/{generate_identifier('export')}"
+        ),
+        'estimatedCompletion': request.query_params.get('estimatedCompletion', isoformat_now()),
+        'digitalSignature': request.query_params.get('digitalSignature', 'SIGNATURE'),
+    }
+    return Response(response)
+
+
+@api_view(['GET'])
+def anomalies(request):
+    anomalies_list = ensure_list(
+        None,
+        [
+            {
+                'type': request.query_params.get('type', 'unusual_access_pattern'),
+                'userId': request.query_params.get('userId', generate_identifier('user')),
+                'description': request.query_params.get(
+                    'description', 'Access pattern requires review'
+                ),
+                'severity': request.query_params.get('severity', 'medium'),
+                'timestamp': isoformat_now(),
+                'score': float(request.query_params.get('score', 0.0)),
+            }
+        ],
+    )
+    return Response({'period': request.query_params.get('period', 'P7D'), 'anomalies': anomalies_list})
+
+
+urlpatterns = [
+    path('events', log_event, name='events'),
+    path('export', export_logs, name='export'),
+    path('anomalies', anomalies, name='anomalies'),
+]

--- a/fhir_portal/services/views/auth.py
+++ b/fhir_portal/services/views/auth.py
@@ -1,0 +1,72 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import ensure_list, generate_identifier, isoformat_now
+
+
+@api_view(['POST'])
+def login(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    response = {
+        'accessToken': payload.get('accessToken', generate_identifier('access-token')),
+        'refreshToken': payload.get('refreshToken', generate_identifier('refresh-token')),
+        'tokenType': payload.get('tokenType', 'Bearer'),
+        'expiresIn': int(payload.get('expiresIn', 3600)),
+        'user': {
+            'id': payload.get('user', {}).get('id', generate_identifier('user')),
+            'email': payload.get('username') or payload.get('email', 'user@example.com'),
+            'roles': ensure_list(payload.get('roles'), ['patient']),
+            'permissions': ensure_list(
+                payload.get('permissions'), ['read:own_records', 'write:own_profile']
+            ),
+        },
+        'issuedAt': isoformat_now(),
+    }
+    return Response(response)
+
+
+@api_view(['POST'])
+def register(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    return Response(
+        {
+            'status': payload.get('status', 'registered'),
+            'userId': generate_identifier('user', override=payload.get('userId')),
+            'verificationMethod': payload.get('verificationMethod', 'email'),
+        }
+    )
+
+
+@api_view(['POST'])
+def password_reset(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    return Response(
+        {
+            'status': payload.get('status', 'sent'),
+            'message': payload.get(
+                'message', 'Password reset instructions sent to email'
+            ),
+            'resetTokenId': generate_identifier('reset', override=payload.get('resetTokenId')),
+            'expiresIn': int(payload.get('expiresIn', 3600)),
+        }
+    )
+
+
+@api_view(['POST'])
+def mfa_setup(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'qrCode': payload.get('qrCode', 'data:image/png;base64,PLACEHOLDER'),
+        'secret': payload.get('secret', 'SAMPLESECRET'),
+        'backupCodes': ensure_list(payload.get('backupCodes'), ['12345678', '87654321']),
+    }
+    return Response(template)
+
+
+urlpatterns = [
+    path('login', login, name='login'),
+    path('register', register, name='register'),
+    path('password-reset', password_reset, name='password-reset'),
+    path('mfa/setup', mfa_setup, name='mfa-setup'),
+]

--- a/fhir_portal/services/views/fhir_gateway.py
+++ b/fhir_portal/services/views/fhir_gateway.py
@@ -1,0 +1,82 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import ensure_list, generate_identifier, isoformat_now
+
+
+@api_view(['GET'])
+def get_patient(request, patient_id: str):
+    response = {
+        'resourceType': 'Patient',
+        'id': patient_id,
+        'meta': {
+            'versionId': request.query_params.get('versionId', '1'),
+            'lastUpdated': isoformat_now(),
+        },
+        'identifier': ensure_list(
+            request.query_params.getlist('identifier') or None,
+            [{'use': 'usual', 'value': 'MRN-SAMPLE'}],
+        ),
+    }
+    return Response(response)
+
+
+@api_view(['GET'])
+def get_capability_statement(request):
+    response = {
+        'resourceType': 'CapabilityStatement',
+        'status': request.query_params.get('status', 'active'),
+        'date': request.query_params.get('date', isoformat_now().split('T')[0]),
+        'publisher': request.query_params.get('publisher', 'Healthcare Organization'),
+        'kind': request.query_params.get('kind', 'instance'),
+        'software': {
+            'name': request.query_params.get('softwareName', 'FHIR Patient Portal'),
+            'version': request.query_params.get('softwareVersion', '1.0.0'),
+        },
+        'fhirVersion': request.query_params.get('fhirVersion', '4.0.1'),
+        'format': ensure_list(request.query_params.getlist('format'), ['json', 'xml']),
+        'rest': ensure_list(
+            None,
+            [
+                {
+                    'mode': 'server',
+                    'resource': [
+                        {
+                            'type': 'Patient',
+                            'interaction': [{'code': 'read'}, {'code': 'search-type'}],
+                        }
+                    ],
+                }
+            ],
+        ),
+    }
+    return Response(response)
+
+
+@api_view(['POST'])
+def batch_operations(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'resourceType': 'Bundle',
+        'type': payload.get('type', 'batch-response'),
+        'entry': ensure_list(
+            payload.get('entry'),
+            [
+                {
+                    'response': {
+                        'status': '200',
+                        'location': f"Patient/{generate_identifier('patient')}",
+                    }
+                }
+            ],
+        ),
+    }
+    return Response(template)
+
+
+urlpatterns = [
+    path('Patient/<str:patient_id>', get_patient, name='fhir-get-patient'),
+    path('metadata', get_capability_statement, name='fhir-metadata'),
+    path('', batch_operations, name='fhir-batch'),
+]

--- a/fhir_portal/services/views/hl7.py
+++ b/fhir_portal/services/views/hl7.py
@@ -1,0 +1,62 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import deep_merge, generate_identifier, isoformat_now
+
+
+def _ingest_template() -> dict:
+    return {
+        'messageId': generate_identifier('msg'),
+        'correlationId': generate_identifier('corr'),
+        'status': 'processed',
+        'timestamp': isoformat_now(),
+        'fhirResources': [
+            {
+                'resourceType': 'Patient',
+                'id': generate_identifier('patient'),
+                'identifier': [{'value': 'MRN-PLACEHOLDER'}],
+                'name': [{'family': 'Sample', 'given': ['Patient']}],
+            }
+        ],
+        'errors': [],
+    }
+
+
+@api_view(['POST'])
+def ingest(request):
+    overrides = request.data if isinstance(request.data, dict) else {}
+    return Response(deep_merge(_ingest_template(), overrides))
+
+
+@api_view(['GET'])
+def parse_status(request, message_id: str):
+    template = {
+        'messageId': message_id,
+        'status': request.query_params.get('status', 'completed'),
+        'processedAt': isoformat_now(),
+        'resourcesCreated': int(request.query_params.get('resourcesCreated', 3)),
+        'errors': [],
+    }
+    return Response(template)
+
+
+@api_view(['POST'])
+def batch(request):
+    overrides = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'batchId': overrides.get('batchId') or generate_identifier('batch'),
+        'totalMessages': overrides.get('totalMessages', 0),
+        'processed': overrides.get('processed', 0),
+        'failed': overrides.get('failed', 0),
+        'processingTime': overrides.get('processingTime', '0s'),
+        'status': overrides.get('status', 'pending'),
+    }
+    return Response(template)
+
+
+urlpatterns = [
+    path('ingest', ingest, name='ingest'),
+    path('parse-status/<str:message_id>', parse_status, name='parse-status'),
+    path('batch', batch, name='batch'),
+]

--- a/fhir_portal/services/views/kafka.py
+++ b/fhir_portal/services/views/kafka.py
@@ -1,0 +1,380 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import deep_merge, ensure_list
+
+
+def _base_event_template() -> dict:
+    return {
+        "eventId": "event-uuid-sample",
+        "eventType": "patient.registered.v1",
+        "eventVersion": "1.0",
+        "timestamp": "2023-09-01T12:30:45Z",
+        "source": {
+            "service": "patient-service",
+            "version": "2.1.0",
+            "instance": "patient-service-pod-3",
+        },
+        "subject": {
+            "type": "Patient",
+            "id": "patient-uuid-123",
+            "tenantId": "tenant-clinic-001",
+        },
+        "data": {
+            "action": "created",
+            "userId": "user-uuid-456",
+            "previousState": None,
+            "currentState": {
+                "status": "active",
+                "registrationComplete": True,
+            },
+        },
+        "metadata": {
+            "correlationId": "corr-uuid-789",
+            "causationId": "cause-uuid-101",
+            "sessionId": "session-uuid-202",
+            "traceId": "trace-uuid-303",
+            "priority": "normal",
+            "retryCount": 0,
+        },
+        "compliance": {
+            "dataClassification": "PHI",
+            "retentionPeriod": "P7Y",
+            "encryptionRequired": True,
+            "auditRequired": True,
+        },
+    }
+
+
+def _topic_configuration_template() -> dict:
+    return {
+        "patient.lifecycle.v1": {
+            "partitions": 12,
+            "replicationFactor": 3,
+            "retentionMs": 604800000,
+            "partitionKey": "patientId",
+            "compressionType": "lz4",
+            "cleanupPolicy": "delete",
+            "messageTypes": ensure_list(
+                None,
+                [
+                    "patient.registered.v1",
+                    "patient.updated.v1",
+                    "patient.merged.v1",
+                    "patient.anonymized.v1",
+                    "patient.consent.changed.v1",
+                ],
+            ),
+        },
+        "patient.search.v1": {
+            "partitions": 6,
+            "replicationFactor": 3,
+            "retentionMs": 86400000,
+            "partitionKey": "searchHash",
+            "compressionType": "snappy",
+            "cleanupPolicy": "delete",
+        },
+        "observation.clinical.v1": {
+            "partitions": 24,
+            "replicationFactor": 3,
+            "retentionMs": 2592000000,
+            "partitionKey": "patientId",
+            "compressionType": "lz4",
+            "messageTypes": ensure_list(
+                None,
+                [
+                    "observation.created.v1",
+                    "observation.updated.v1",
+                    "observation.alert.triggered.v1",
+                    "observation.batch.processed.v1",
+                ],
+            ),
+        },
+        "appointment.scheduling.v1": {
+            "partitions": 8,
+            "replicationFactor": 3,
+            "retentionMs": 1209600000,
+            "partitionKey": "practitionerId",
+            "compressionType": "lz4",
+        },
+        "security.events.v1": {
+            "partitions": 16,
+            "replicationFactor": 3,
+            "retentionMs": 31536000000,
+            "partitionKey": "userId",
+            "compressionType": "gzip",
+            "cleanupPolicy": "compact",
+        },
+        "audit.trail.v1": {
+            "partitions": 32,
+            "replicationFactor": 3,
+            "retentionMs": 220752000000,
+            "partitionKey": "resourceId",
+            "compressionType": "gzip",
+            "cleanupPolicy": "compact",
+        },
+        "dlq.failed-events.v1": {
+            "partitions": 4,
+            "replicationFactor": 3,
+            "retentionMs": 604800000,
+            "compressionType": "gzip",
+            "retryPolicy": {
+                "maxRetries": 3,
+                "backoffStrategy": "exponential",
+                "initialDelay": "PT1S",
+                "maxDelay": "PT30S",
+                "jitterEnabled": True,
+            },
+            "alerting": {
+                "enabled": True,
+                "threshold": 100,
+                "timeWindow": "PT1H",
+                "channels": ["slack", "email"],
+            },
+        },
+    }
+
+
+def _partitioning_strategy_template() -> dict:
+    return {
+        "patient.lifecycle.v1": {
+            "partitionKey": "data.patientId",
+            "keyExtractor": "$.subject.id",
+            "orderingGuarantee": "per_patient",
+        },
+        "observation.clinical.v1": {
+            "partitionKey": "data.patientId",
+            "keyExtractor": "$.data.subject.reference",
+            "orderingGuarantee": "per_patient_per_observation_type",
+        },
+        "appointment.scheduling.v1": {
+            "partitionKey": "data.practitionerId",
+            "orderingGuarantee": "per_practitioner",
+        },
+        "audit.trail.v1": {
+            "partitionKey": "data.resourceId",
+            "orderingGuarantee": "per_resource",
+        },
+    }
+
+
+def _consumer_groups_template() -> dict:
+    return {
+        "realtime": ensure_list(
+            None,
+            [
+                {
+                    "groupId": "patient-service-realtime",
+                    "topics": [
+                        "hl7.message.received.v1",
+                        "user.registered.v1",
+                        "consent.updated.v1",
+                    ],
+                    "processingMode": "exactly_once",
+                    "maxPollRecords": 100,
+                    "sessionTimeoutMs": 30000,
+                    "autoCommit": False,
+                },
+                {
+                    "groupId": "notification-service-immediate",
+                    "topics": [
+                        "appointment.booked.v1",
+                        "observation.alert.triggered.v1",
+                        "security.alert.triggered.v1",
+                    ],
+                    "processingMode": "at_least_once",
+                    "maxPollRecords": 50,
+                    "priorityQueues": {
+                        "critical": ["security.alert.triggered.v1"],
+                        "high": ["observation.alert.triggered.v1"],
+                        "normal": ["appointment.booked.v1"],
+                    },
+                },
+            ],
+        ),
+        "batch": [
+            {
+                "groupId": "analytics-service-batch",
+                "topics": [
+                    "patient.lifecycle.v1",
+                    "observation.clinical.v1",
+                    "appointment.scheduling.v1",
+                ],
+                "processingMode": "batch",
+                "batchSize": 1000,
+                "batchTimeoutMs": 60000,
+                "windowDuration": "PT5M",
+            }
+        ],
+        "audit": [
+            {
+                "groupId": "audit-service-compliance",
+                "topics": ["*.*.v1"],
+                "processingMode": "exactly_once",
+                "durabilityGuarantee": "persistent",
+                "retentionPolicy": "P7Y",
+                "encryptionEnabled": True,
+            }
+        ],
+    }
+
+
+def _monitoring_template() -> dict:
+    return {
+        "monitoring": {
+            "metricsReporter": "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor",
+            "jmxMetrics": ensure_list(
+                None,
+                [
+                    "kafka.producer:type=producer-metrics,client-id=*",
+                    "kafka.consumer:type=consumer-metrics,client-id=*",
+                    "kafka.streams:type=stream-metrics,client-id=*",
+                ],
+            ),
+            "alertRules": [
+                {
+                    "metric": "consumer_lag",
+                    "threshold": 10000,
+                    "duration": "PT5M",
+                    "severity": "warning",
+                },
+                {
+                    "metric": "error_rate",
+                    "threshold": 0.05,
+                    "duration": "PT2M",
+                    "severity": "critical",
+                },
+            ],
+        },
+        "healthChecks": {
+            "producerLatency": {
+                "threshold": "PT0.1S",
+                "alertChannel": "ops-team",
+            },
+            "consumerLag": {
+                "threshold": 5000,
+                "alertChannel": "dev-team",
+            },
+            "diskUsage": {
+                "threshold": 0.8,
+                "alertChannel": "infrastructure",
+            },
+            "replicationStatus": {
+                "minInSyncReplicas": 2,
+                "alertChannel": "ops-team",
+            },
+        },
+    }
+
+
+def _schema_registry_template() -> dict:
+    return {
+        "schemaRegistry": {
+            "url": "http://schema-registry:8081",
+            "compatibilityLevel": "BACKWARD",
+            "subjectNaming": "TopicNameStrategy",
+            "schemas": {
+                "patient.lifecycle.v1-value": {
+                    "version": 2,
+                    "evolution": "backward_compatible",
+                    "changes": [
+                        "added optional field 'preferredLanguage'",
+                        "added optional field 'communicationPreferences'",
+                    ],
+                }
+            },
+        }
+    }
+
+
+def _security_template() -> dict:
+    return {
+        "security": {
+            "protocol": "SASL_SSL",
+            "saslMechanism": "SCRAM-SHA-512",
+            "sslTruststoreLocation": "/opt/kafka/ssl/truststore.jks",
+            "sslKeystoreLocation": "/opt/kafka/ssl/keystore.jks",
+            "encryption": {
+                "inTransit": "TLS 1.3",
+                "atRest": "AES-256-GCM",
+            },
+            "acls": [
+                {
+                    "principal": "User:patient-service",
+                    "operations": ["Read", "Write"],
+                    "topics": ["patient.lifecycle.v1"],
+                },
+                {
+                    "principal": "User:audit-service",
+                    "operations": ["Read"],
+                    "topics": ["*.*.v1"],
+                },
+            ],
+        }
+    }
+
+
+@api_view(["GET"])
+def event_schema(request):
+    """Return the base Kafka event schema used across services."""
+    overrides = request.query_params.dict()
+    return Response(deep_merge(_base_event_template(), overrides))
+
+
+@api_view(["GET"])
+def configuration(request):
+    """Provide the Kafka topic, partitioning, consumer, and monitoring defaults."""
+    template = {
+        "topics": _topic_configuration_template(),
+        "partitioning": _partitioning_strategy_template(),
+        "consumerGroups": _consumer_groups_template(),
+        "monitoring": _monitoring_template(),
+    }
+    section = request.query_params.get("section")
+    if section:
+        return Response(template.get(section))
+    return Response(template)
+
+
+@api_view(["GET"])
+def governance(request):
+    """Expose schema registry, retry, and security guidance."""
+    retry_policy = {
+        "retryPolicy": {
+            "retryableExceptions": ensure_list(
+                None,
+                [
+                    "org.apache.kafka.common.errors.TimeoutException",
+                    "org.springframework.dao.TransientDataAccessException",
+                    "java.net.SocketTimeoutException",
+                ],
+            ),
+            "nonRetryableExceptions": ensure_list(
+                None,
+                [
+                    "com.fhir.validation.ValidationException",
+                    "org.springframework.security.access.AccessDeniedException",
+                    "com.fhir.patient.PatientNotFoundException",
+                ],
+            ),
+            "maxRetries": 3,
+            "backoffPolicy": {
+                "type": "exponential",
+                "initialInterval": 1000,
+                "multiplier": 2.0,
+                "maxInterval": 30000,
+                "randomizationFactor": 0.1,
+            },
+        }
+    }
+    template = deep_merge(_schema_registry_template(), _security_template())
+    template = deep_merge(template, retry_policy)
+    return Response(template)
+
+
+urlpatterns = [
+    path("events/schema", event_schema, name="event-schema"),
+    path("config", configuration, name="configuration"),
+    path("governance", governance, name="governance"),
+]

--- a/fhir_portal/services/views/notifications.py
+++ b/fhir_portal/services/views/notifications.py
@@ -1,0 +1,61 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import ensure_list, generate_identifier, isoformat_now
+
+
+@api_view(['POST'])
+def send_notification(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    channels = ensure_list(
+        payload.get('channels'),
+        [
+            {
+                'type': 'email',
+                'status': 'queued',
+                'estimatedDelivery': isoformat_now(),
+            }
+        ],
+    )
+    template = {
+        'notificationId': generate_identifier('notif', override=payload.get('notificationId')),
+        'status': payload.get('status', 'scheduled'),
+        'channels': channels,
+        'scheduledAt': payload.get('scheduledAt', isoformat_now()),
+    }
+    return Response(template)
+
+
+@api_view(['POST'])
+def create_template(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    return Response(
+        {
+            'templateId': generate_identifier('template', override=payload.get('templateId')),
+            'name': payload.get('name', 'appointment_reminder'),
+            'channels': payload.get('channels', {}),
+            'variables': ensure_list(payload.get('variables'), ['patientName']),
+        }
+    )
+
+
+@api_view(['POST'])
+def bulk(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    recipients = ensure_list(payload.get('recipients'), [])
+    return Response(
+        {
+            'campaignName': payload.get('campaignName', 'campaign'),
+            'status': payload.get('status', 'scheduled'),
+            'scheduledAt': payload.get('scheduledAt', isoformat_now()),
+            'recipientCount': len(recipients),
+        }
+    )
+
+
+urlpatterns = [
+    path('send', send_notification, name='send'),
+    path('templates', create_template, name='templates'),
+    path('bulk', bulk, name='bulk'),
+]

--- a/fhir_portal/services/views/observations.py
+++ b/fhir_portal/services/views/observations.py
@@ -1,0 +1,111 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import deep_merge, ensure_list, generate_identifier, isoformat_now
+
+
+def _observation_template(payload: dict | None = None) -> dict:
+    payload = payload or {}
+    return {
+        'resourceType': payload.get('resourceType', 'Observation'),
+        'id': generate_identifier('obs', override=payload.get('id')),
+        'meta': {
+            'versionId': payload.get('meta', {}).get('versionId', '1'),
+            'lastUpdated': isoformat_now(),
+        },
+        'status': payload.get('status', 'final'),
+        'category': ensure_list(
+            payload.get('category'),
+            [
+                {
+                    'coding': [
+                        {
+                            'system': 'http://terminology.hl7.org/CodeSystem/observation-category',
+                            'code': 'vital-signs',
+                        }
+                    ]
+                }
+            ],
+        ),
+    }
+
+
+@api_view(['POST'])
+def create_vital_sign(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    return Response(deep_merge(_observation_template(payload), payload))
+
+
+@api_view(['POST'])
+def lab_results(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    bundle_template = {
+        'resourceType': 'Bundle',
+        'type': payload.get('type', 'transaction-response'),
+        'entry': ensure_list(
+            payload.get('entry'),
+            [
+                {
+                    'response': {
+                        'status': '201 Created',
+                        'location': f"Observation/{generate_identifier('obs')}",
+                    }
+                }
+            ],
+        ),
+    }
+    return Response(bundle_template)
+
+
+@api_view(['GET'])
+def trends(request, patient_id: str):
+    query = request.query_params
+    time_range = {
+        'start': query.get('start', isoformat_now()),
+        'end': query.get('end', isoformat_now()),
+    }
+    data_points = ensure_list(
+        None,
+        [
+            {
+                'timestamp': isoformat_now(),
+                'value': float(query.get('value', 0)),
+                'status': query.get('status', 'normal'),
+            }
+        ],
+    )
+    response = {
+        'patientId': patient_id,
+        'observationType': query.get('observationType', 'glucose'),
+        'unit': query.get('unit', 'mg/dL'),
+        'timeRange': time_range,
+        'dataPoints': data_points,
+        'referenceRanges': {
+            'low': float(query.get('low', 0)),
+            'high': float(query.get('high', 0)),
+        },
+    }
+    return Response(response)
+
+
+@api_view(['POST'])
+def configure_alert(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'patientId': payload.get('patientId', generate_identifier('patient')),
+        'observationCode': payload.get('observationCode', 'unknown'),
+        'status': payload.get('status', 'configured'),
+        'notificationChannels': ensure_list(
+            payload.get('notificationChannels'), ['email', 'sms']
+        ),
+    }
+    return Response(template)
+
+
+urlpatterns = [
+    path('', create_vital_sign, name='create'),
+    path('lab-results', lab_results, name='lab-results'),
+    path('<str:patient_id>/trends', trends, name='trends'),
+    path('alerts/configure', configure_alert, name='configure-alert'),
+]

--- a/fhir_portal/services/views/patients.py
+++ b/fhir_portal/services/views/patients.py
@@ -1,0 +1,123 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import deep_merge, ensure_list, generate_identifier, isoformat_now
+
+
+def _patient_template(payload: dict | None = None) -> dict:
+    payload = payload or {}
+    identifiers = ensure_list(
+        payload.get('identifier'),
+        [
+            {
+                'use': 'usual',
+                'type': {
+                    'coding': [
+                        {
+                            'system': 'http://terminology.hl7.org/CodeSystem/v2-0203',
+                            'code': 'MR',
+                        }
+                    ]
+                },
+                'value': 'MRN-SAMPLE',
+            }
+        ],
+    )
+    names = ensure_list(
+        payload.get('name'),
+        [
+            {
+                'use': 'official',
+                'family': 'Sample',
+                'given': ['Patient'],
+            }
+        ],
+    )
+    return {
+        'resourceType': 'Patient',
+        'id': generate_identifier('patient', override=payload.get('id')),
+        'meta': {
+            'versionId': payload.get('meta', {}).get('versionId', '1'),
+            'lastUpdated': isoformat_now(),
+        },
+        'identifier': identifiers,
+        'name': names,
+        'gender': payload.get('gender', 'unknown'),
+        'birthDate': payload.get('birthDate', '1970-01-01'),
+    }
+
+
+@api_view(['POST'])
+def register(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    return Response(deep_merge(_patient_template(payload), payload))
+
+
+@api_view(['PUT'])
+def update(request, patient_id: str):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = _patient_template({**payload, 'id': patient_id})
+    template['meta']['versionId'] = payload.get('meta', {}).get('versionId', '2')
+    return Response(deep_merge(template, payload))
+
+
+@api_view(['GET'])
+def search(request):
+    name_query = request.query_params.getlist('name')
+    if name_query:
+        names = [{'text': value} for value in name_query]
+    else:
+        names = [{'family': 'Sample', 'given': ['Patient']}]
+    entries = [
+        {
+            'resource': {
+                'resourceType': 'Patient',
+                'id': request.query_params.get('id', generate_identifier('patient')),
+                'name': names,
+            }
+        }
+    ]
+    response = {
+        'resourceType': 'Bundle',
+        'type': 'searchset',
+        'total': int(request.query_params.get('total', len(entries))),
+        'entry': entries,
+    }
+    return Response(response)
+
+
+@api_view(['POST'])
+def merge(request, source_id: str, target_id: str):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'status': payload.get('status', 'merged'),
+        'resultPatientId': target_id,
+        'mergedFields': payload.get('mergedFields', ['telecom', 'address']),
+        'auditId': generate_identifier('audit', override=payload.get('auditId')),
+    }
+    return Response(template)
+
+
+@api_view(['GET'])
+def export(request, patient_id: str):
+    template = {
+        'exportId': generate_identifier('export'),
+        'status': request.query_params.get('status', 'completed'),
+        'downloadUrl': request.query_params.get(
+            'downloadUrl', f'/api/v1/exports/{generate_identifier("export")}/download'
+        ),
+        'format': request.query_params.get('format', 'pdf'),
+        'size': request.query_params.get('size', '0MB'),
+        'expiresAt': request.query_params.get('expiresAt', isoformat_now()),
+    }
+    return Response(template)
+
+
+urlpatterns = [
+    path('', register, name='register'),
+    path('search', search, name='search'),
+    path('<str:source_id>/merge/<str:target_id>', merge, name='merge'),
+    path('<str:patient_id>/export', export, name='export'),
+    path('<str:patient_id>', update, name='update'),
+]

--- a/fhir_portal/services/views/roles.py
+++ b/fhir_portal/services/views/roles.py
@@ -1,0 +1,61 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import ensure_list, generate_identifier, isoformat_now
+
+
+@api_view(['POST'])
+def assign(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'assignmentId': generate_identifier('assignment', override=payload.get('assignmentId')),
+        'status': payload.get('status', 'active'),
+        'permissions': ensure_list(
+            payload.get('permissions'),
+            ['read:patient_records', 'write:observations', 'manage:department_users'],
+        ),
+        'effectiveDate': payload.get('effectiveDate', isoformat_now()),
+        'expiryDate': payload.get('expiryDate'),
+    }
+    return Response(template)
+
+
+@api_view(['POST'])
+def validate(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    return Response(
+        {
+            'allowed': bool(payload.get('allowed', True)),
+            'decision': payload.get('decision', 'permit'),
+            'reason': payload.get(
+                'reason', 'User has appropriate role with required permission'
+            ),
+            'conditions': ensure_list(payload.get('conditions'), ['audit_required']),
+        }
+    )
+
+
+@api_view(['POST'])
+def abac(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    return Response(
+        {
+            'decision': payload.get('decision', 'permit'),
+            'explanation': payload.get(
+                'explanation',
+                'Subject, resource, and environment attributes satisfy policy rules',
+            ),
+            'obligations': ensure_list(
+                payload.get('obligations'), ['log_access', 'session_timeout']
+            ),
+            'evaluatedAt': isoformat_now(),
+        }
+    )
+
+
+urlpatterns = [
+    path('assign', assign, name='assign'),
+    path('validate', validate, name='validate'),
+    path('abac/evaluate', abac, name='abac'),
+]

--- a/fhir_portal/services/views/telemedicine.py
+++ b/fhir_portal/services/views/telemedicine.py
@@ -1,0 +1,83 @@
+from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+
+from ..sample_utils import ensure_list, generate_identifier, isoformat_now
+
+
+@api_view(['POST'])
+def create_session(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'sessionId': generate_identifier('session', override=payload.get('sessionId')),
+        'joinUrls': payload.get(
+            'joinUrls',
+            {
+                'patient': 'https://telemedicine.example.com/join/patient-token',
+                'provider': 'https://telemedicine.example.com/join/provider-token',
+            },
+        ),
+        'accessWindow': payload.get(
+            'accessWindow',
+            {
+                'start': isoformat_now(),
+                'end': isoformat_now(),
+            },
+        ),
+        'sessionSettings': payload.get(
+            'sessionSettings',
+            {
+                'recordingEnabled': False,
+                'chatEnabled': True,
+                'screenShareEnabled': True,
+            },
+        ),
+    }
+    return Response(template)
+
+
+@api_view(['POST'])
+def record_consent(request):
+    payload = request.data if isinstance(request.data, dict) else {}
+    template = {
+        'sessionId': payload.get('sessionId', generate_identifier('session')),
+        'userId': payload.get('userId', generate_identifier('user')),
+        'consentType': payload.get('consentType', 'video_recording'),
+        'granted': bool(payload.get('granted', True)),
+        'recordedAt': payload.get('timestamp', isoformat_now()),
+        'ipAddress': payload.get('ipAddress'),
+    }
+    return Response(template)
+
+
+@api_view(['GET'])
+def metrics(request, session_id: str):
+    query = request.query_params
+    response = {
+        'sessionId': session_id,
+        'qualityMetrics': {
+            'averageLatency': float(query.get('averageLatency', 0)),
+            'packetLoss': float(query.get('packetLoss', 0)),
+            'videoQuality': query.get('videoQuality', 'HD'),
+            'audioQuality': query.get('audioQuality', 'excellent'),
+        },
+        'duration': int(query.get('duration', 0)),
+        'participants': ensure_list(
+            None,
+            [
+                {
+                    'userId': generate_identifier('user'),
+                    'connectionTime': int(query.get('connectionTime', 0)),
+                    'disconnections': int(query.get('disconnections', 0)),
+                }
+            ],
+        ),
+    }
+    return Response(response)
+
+
+urlpatterns = [
+    path('sessions', create_session, name='create-session'),
+    path('consent', record_consent, name='consent'),
+    path('sessions/<str:session_id>/metrics', metrics, name='metrics'),
+]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,61 @@
+# FHIR Patient Portal Frontend
+
+A React + Redux single-page application that documents and exercises the REST and Kafka APIs for the FHIR Patient Portal platform.
+
+## Features
+
+- Service catalog that mirrors the twelve services defined in the platform specification, including Kafka topic guidance.
+- Rich endpoint cards that surface validation rules, Kafka topics, query parameters, and request/response samples.
+- Built-in API console that can fire requests against the Django backend using the configured base URL and bearer token.
+- Environment drawer for updating the API base URL, bearer token, and Kafka bootstrap servers without rebuilding the app.
+- Responsive layout with sidebar navigation optimised for desktop and tablet breakpoints.
+
+## Getting Started
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+By default the development server listens on [http://localhost:5173](http://localhost:5173). Update the environment drawer with your backend origin (for example `http://localhost:8000`).
+
+### Production Build
+
+```bash
+npm run build
+npm run preview
+```
+
+The build command outputs a static bundle under `dist/` that can be served by any static file host or reverse-proxy in front of the Django backend.
+
+## Project Structure
+
+```
+frontend/
+├── index.html              # Vite entry point
+├── package.json            # npm dependencies
+├── src/
+│   ├── App.jsx             # Application shell
+│   ├── styles.css          # Global styles
+│   ├── app/store.js        # Redux store
+│   ├── components/         # UI components (sidebar, headers, endpoint cards)
+│   └── features/           # Redux slices and feature-specific components
+└── vite.config.js          # Vite configuration
+```
+
+## API Console
+
+- **Send Request** executes the sample payload against the configured backend. Update headers or JSON as needed before sending.
+- **Reset Sample** restores the canonical request body from the specification.
+- **Show Response** toggles between example payloads and live responses from the backend.
+
+> **Note:** If you do not have the backend running locally the Send Request action will surface a network error inside the response panel. The rest of the documentation remains fully interactive.
+
+## Kafka Documentation
+
+The Kafka section consolidates topic architecture, schemas, retention settings, dead-letter queues, consumer patterns, monitoring, and security expectations from the specification. Each card is copy-ready to feed into Confluence, architecture diagrams, or observability dashboards.
+
+## Browser Compatibility
+
+The application targets evergreen browsers (Chrome, Edge, Firefox, Safari). No TypeScript or CSS frameworks are required.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FHIR Patient Portal</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "fhir-patient-portal-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "^1.9.7",
+    "axios": "^1.6.7",
+    "prop-types": "^15.8.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-redux": "^8.1.3",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.0.10"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,31 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { useMemo } from 'react';
+import Sidebar from './components/Sidebar.jsx';
+import Header from './components/Header.jsx';
+import ServiceContent from './components/ServiceContent.jsx';
+import { selectService } from './features/services/servicesSlice.js';
+
+export default function App() {
+  const dispatch = useDispatch();
+  const services = useSelector((state) => state.services.catalog);
+  const selectedService = useSelector((state) => state.services.selectedService);
+
+  const currentService = useMemo(
+    () => services.find((service) => service.key === selectedService) ?? services[0],
+    [services, selectedService]
+  );
+
+  return (
+    <div className="app-shell">
+      <Sidebar
+        services={services}
+        selected={selectedService}
+        onSelect={(key) => dispatch(selectService(key))}
+      />
+      <div className="main-area">
+        <Header service={currentService} />
+        <ServiceContent service={currentService} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/store.js
+++ b/frontend/src/app/store.js
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import configReducer from '../features/config/configSlice.js';
+import consoleReducer from '../features/console/consoleSlice.js';
+import servicesReducer from '../features/services/servicesSlice.js';
+
+export const store = configureStore({
+  reducer: {
+    config: configReducer,
+    console: consoleReducer,
+    services: servicesReducer
+  }
+});

--- a/frontend/src/components/EndpointCard.jsx
+++ b/frontend/src/components/EndpointCard.jsx
@@ -1,0 +1,186 @@
+import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { useMemo } from 'react';
+import { setRequest } from '../features/console/consoleSlice.js';
+import { sendServiceRequest, toggleEndpoint } from '../features/services/servicesSlice.js';
+
+export default function EndpointCard({ service, endpoint }) {
+  const dispatch = useDispatch();
+  const expanded = useSelector((state) => state.services.expandedEndpoints[`${service.key}:${endpoint.id}`]);
+  const sessionKey = `${service.key}${endpoint.fullPath}`;
+  const sessionState = useSelector((state) => state.console.sessions[sessionKey]);
+  const requestBody = sessionState?.request ?? endpoint.requestPayload ?? '';
+  const loading = sessionState?.loading ?? false;
+  const response = sessionState?.response;
+  const error = sessionState?.error;
+  const status = sessionState?.status;
+
+  const methodClass = useMemo(() => `method-pill method-${endpoint.method}`, [endpoint.method]);
+
+  const isExecutable = endpoint.method !== 'DESIGN';
+
+  const handleExecute = () => {
+    if (!isExecutable) {
+      return;
+    }
+    dispatch(sendServiceRequest({
+      serviceKey: service.key,
+      endpointKey: endpoint.fullPath,
+      body: requestBody,
+      params: undefined
+    }));
+  };
+
+  const handleReset = () => {
+    dispatch(
+      setRequest({
+        key: sessionKey,
+        body: endpoint.requestPayload ?? ''
+      })
+    );
+  };
+
+  return (
+    <div className="endpoint-card">
+      <div className="endpoint-header">
+        <span className={methodClass}>{endpoint.method}</span>
+        <div>
+          <strong>{endpoint.name}</strong>
+          <div className="small-text">{endpoint.summary}</div>
+          <div className="small-text">{endpoint.fullPath}</div>
+        </div>
+      </div>
+
+      {endpoint.requestHeaders?.length ? (
+        <div className="panel-stack">
+          <div className="section-title">Headers</div>
+          <div className="table-like">
+            {endpoint.requestHeaders.map((header) => (
+              <div className="row" key={header.key}>
+                <span className="label">{header.key}</span>
+                <span>{header.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {endpoint.validationRules?.length ? (
+        <div className="panel-stack">
+          <div className="section-title">Validation Rules</div>
+          <ul className="small-text" style={{ margin: 0 }}>
+            {endpoint.validationRules.map((rule) => (
+              <li key={rule}>{rule}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {endpoint.kafkaEvents?.length ? (
+        <div className="panel-stack">
+          <div className="section-title">Kafka Events</div>
+          <div className="tag-list">
+            {endpoint.kafkaEvents.map((topic) => (
+              <span className="tag" key={topic}>
+                {topic}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {endpoint.queryParameters?.length ? (
+        <div className="panel-stack">
+          <div className="section-title">Query Parameters</div>
+          <div className="tag-list">
+            {endpoint.queryParameters.map((param) => (
+              <span className="tag" key={param}>
+                {param}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {endpoint.requestPayload ? (
+        <div className="panel-stack">
+          <div className="section-title">Sample Request</div>
+          <textarea
+            className="json-input"
+            value={requestBody}
+            onChange={(event) =>
+              dispatch(
+                setRequest({
+                  key: sessionKey,
+                  body: event.target.value
+                })
+              )
+            }
+          />
+          <div className="button-row">
+            {isExecutable ? (
+              <button type="button" className="primary" onClick={handleExecute} disabled={loading}>
+                {loading ? 'Sending…' : 'Send Request'}
+              </button>
+            ) : null}
+            <button type="button" className="secondary" onClick={handleReset}>
+              Reset sample
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => dispatch(toggleEndpoint({ serviceKey: service.key, endpointKey: endpoint.id }))}
+            >
+              {expanded ? 'Hide Response' : 'Show Response'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="button-row">
+          {isExecutable ? (
+            <button type="button" className="primary" onClick={handleExecute} disabled={loading}>
+              {loading ? 'Sending…' : 'Send Request'}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => dispatch(toggleEndpoint({ serviceKey: service.key, endpointKey: endpoint.id }))}
+          >
+            {expanded ? 'Hide Details' : 'Show Details'}
+          </button>
+        </div>
+      )}
+
+      {expanded && (response || error || endpoint.responsePayload) ? (
+        <div className="panel-stack">
+          <div className="section-title">Response</div>
+          {status ? <div className="badge">HTTP {status}</div> : null}
+          {error ? (
+            <div className="alert">
+              <strong>Request failed:</strong>
+              <pre className="code-block" style={{ marginTop: '0.5rem' }}>
+                {typeof error === 'string' ? error : JSON.stringify(error, null, 2)}
+              </pre>
+            </div>
+          ) : response ? (
+            <pre className="code-block">{JSON.stringify(response, null, 2)}</pre>
+          ) : (
+            <pre className="code-block">{endpoint.responsePayload ?? 'No response example available.'}</pre>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+EndpointCard.propTypes = {
+  service: PropTypes.shape({ key: PropTypes.string.isRequired }).isRequired,
+  endpoint: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    method: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    summary: PropTypes.string,
+    fullPath: PropTypes.string
+  }).isRequired
+};

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import ConfigPanel from '../features/config/ConfigPanel.jsx';
+
+export default function Header({ service }) {
+  return (
+    <header className="header">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '1rem' }}>
+        <div>
+          <div className="section-title">Current Service</div>
+          <h2 style={{ margin: '0.25rem 0 0' }}>{service?.name ?? 'Select a service'}</h2>
+          <p className="small-text" style={{ maxWidth: '720px', marginTop: '0.25rem' }}>
+            {service?.description}
+          </p>
+        </div>
+        <ConfigPanel />
+      </div>
+    </header>
+  );
+}
+
+Header.propTypes = {
+  service: PropTypes.shape({
+    name: PropTypes.string,
+    description: PropTypes.string
+  })
+};
+
+Header.defaultProps = {
+  service: null
+};

--- a/frontend/src/components/KafkaGuidance.jsx
+++ b/frontend/src/components/KafkaGuidance.jsx
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+
+export default function KafkaGuidance({ endpoints }) {
+  return (
+    <div className="grid">
+      {endpoints.map((endpoint) => (
+        <div key={endpoint.id} className="endpoint-card">
+          <div className="endpoint-header">
+            <span className="method-pill method-DESIGN">KAFKA</span>
+            <div>
+              <strong>{endpoint.name}</strong>
+              <div className="small-text">{endpoint.summary}</div>
+            </div>
+          </div>
+          <pre className="code-block">{endpoint.responsePayload}</pre>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+KafkaGuidance.propTypes = {
+  endpoints: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+      summary: PropTypes.string,
+      responsePayload: PropTypes.string
+    })
+  ).isRequired
+};

--- a/frontend/src/components/ServiceContent.jsx
+++ b/frontend/src/components/ServiceContent.jsx
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types';
+import EndpointCard from './EndpointCard.jsx';
+import KafkaGuidance from './KafkaGuidance.jsx';
+
+export default function ServiceContent({ service }) {
+  if (!service) {
+    return (
+      <main className="content">
+        <div className="card">Select a service to explore its endpoints.</div>
+      </main>
+    );
+  }
+
+  const isKafka = service.key === 'kafka';
+
+  return (
+    <main className="content">
+      <div className="card">
+        <div className="section-title">Base URL</div>
+        <div className="badge">{service.baseUrl || 'Documentation'}</div>
+      </div>
+
+      {isKafka ? (
+        <KafkaGuidance endpoints={service.endpoints} />
+      ) : (
+        <div className="grid">
+          {service.endpoints.map((endpoint) => (
+            <EndpointCard key={endpoint.id} service={service} endpoint={endpoint} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+ServiceContent.propTypes = {
+  service: PropTypes.shape({
+    key: PropTypes.string,
+    baseUrl: PropTypes.string,
+    endpoints: PropTypes.arrayOf(PropTypes.object)
+  })
+};
+
+ServiceContent.defaultProps = {
+  service: null
+};

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,52 @@
+import PropTypes from 'prop-types';
+
+const serviceOrder = [
+  'hl7-parser',
+  'patients',
+  'observations',
+  'appointments',
+  'auth',
+  'roles',
+  'telemedicine',
+  'notifications',
+  'analytics',
+  'audit',
+  'fhir-gateway',
+  'kafka'
+];
+
+export default function Sidebar({ services, selected, onSelect }) {
+  const sorted = [...services].sort(
+    (a, b) => serviceOrder.indexOf(a.key) - serviceOrder.indexOf(b.key)
+  );
+
+  return (
+    <aside className="sidebar">
+      <h1>FHIR Patient Portal</h1>
+      <p className="small-text">Explore REST endpoints and event-driven contracts</p>
+      <nav>
+        {sorted.map((service) => (
+          <button
+            key={service.key}
+            type="button"
+            className={selected === service.key ? 'active' : ''}
+            onClick={() => onSelect(service.key)}
+          >
+            {service.name}
+          </button>
+        ))}
+      </nav>
+      <div className="small-text">Built with React + Redux Toolkit</div>
+    </aside>
+  );
+}
+
+Sidebar.propTypes = {
+  services: PropTypes.arrayOf(PropTypes.shape({ key: PropTypes.string.isRequired })).isRequired,
+  selected: PropTypes.string,
+  onSelect: PropTypes.func.isRequired
+};
+
+Sidebar.defaultProps = {
+  selected: null
+};

--- a/frontend/src/features/config/ConfigPanel.jsx
+++ b/frontend/src/features/config/ConfigPanel.jsx
@@ -1,0 +1,51 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { useState } from 'react';
+import { setBaseUrl, setToken, setKafkaBootstrap } from './configSlice.js';
+
+export default function ConfigPanel() {
+  const dispatch = useDispatch();
+  const { baseUrl, token, kafkaBootstrap } = useSelector((state) => state.config);
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="card" style={{ minWidth: '320px', padding: '1rem' }}>
+      <button type="button" className="secondary" onClick={() => setExpanded((state) => !state)}>
+        {expanded ? 'Hide environment' : 'Show environment'}
+      </button>
+      {expanded ? (
+        <div className="panel-stack" style={{ marginTop: '1rem' }}>
+          <label className="small-text" htmlFor="config-base-url">
+            Base API URL
+          </label>
+          <input
+            id="config-base-url"
+            type="text"
+            value={baseUrl}
+            onChange={(event) => dispatch(setBaseUrl(event.target.value))}
+            style={{ padding: '0.5rem', borderRadius: '0.5rem', border: '1px solid #cbd5f5' }}
+          />
+          <label className="small-text" htmlFor="config-token">
+            Bearer token
+          </label>
+          <input
+            id="config-token"
+            type="text"
+            value={token}
+            onChange={(event) => dispatch(setToken(event.target.value))}
+            style={{ padding: '0.5rem', borderRadius: '0.5rem', border: '1px solid #cbd5f5' }}
+          />
+          <label className="small-text" htmlFor="config-kafka">
+            Kafka bootstrap servers
+          </label>
+          <input
+            id="config-kafka"
+            type="text"
+            value={kafkaBootstrap}
+            onChange={(event) => dispatch(setKafkaBootstrap(event.target.value))}
+            style={{ padding: '0.5rem', borderRadius: '0.5rem', border: '1px solid #cbd5f5' }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/config/configSlice.js
+++ b/frontend/src/features/config/configSlice.js
@@ -1,0 +1,29 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  baseUrl: 'http://localhost:8000',
+  token: '',
+  kafkaBootstrap: 'kafka://localhost:9092'
+};
+
+const configSlice = createSlice({
+  name: 'config',
+  initialState,
+  reducers: {
+    setBaseUrl(state, action) {
+      state.baseUrl = action.payload;
+    },
+    setToken(state, action) {
+      state.token = action.payload;
+    },
+    setKafkaBootstrap(state, action) {
+      state.kafkaBootstrap = action.payload;
+    },
+    resetConfig() {
+      return initialState;
+    }
+  }
+});
+
+export const { setBaseUrl, setToken, setKafkaBootstrap, resetConfig } = configSlice.actions;
+export default configSlice.reducer;

--- a/frontend/src/features/console/consoleSlice.js
+++ b/frontend/src/features/console/consoleSlice.js
@@ -1,0 +1,51 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  sessions: {}
+};
+
+const consoleSlice = createSlice({
+  name: 'console',
+  initialState,
+  reducers: {
+    setRequest(state, action) {
+      const { key, body } = action.payload;
+      if (!state.sessions[key]) {
+        state.sessions[key] = { request: '', response: null, status: null, error: null, loading: false };
+      }
+      state.sessions[key].request = body;
+    },
+    setLoading(state, action) {
+      const { key, loading } = action.payload;
+      if (!state.sessions[key]) {
+        state.sessions[key] = { request: '', response: null, status: null, error: null, loading: false };
+      }
+      state.sessions[key].loading = loading;
+      if (loading) {
+        state.sessions[key].error = null;
+      }
+    },
+    setResponse(state, action) {
+      const { key, response, status } = action.payload;
+      if (!state.sessions[key]) {
+        state.sessions[key] = { request: '', response: null, status: null, error: null, loading: false };
+      }
+      state.sessions[key].response = response;
+      state.sessions[key].status = status;
+      state.sessions[key].loading = false;
+      state.sessions[key].error = null;
+    },
+    setError(state, action) {
+      const { key, error, status } = action.payload;
+      if (!state.sessions[key]) {
+        state.sessions[key] = { request: '', response: null, status: null, error: null, loading: false };
+      }
+      state.sessions[key].error = error;
+      state.sessions[key].status = status ?? null;
+      state.sessions[key].loading = false;
+    }
+  }
+});
+
+export const { setRequest, setLoading, setResponse, setError } = consoleSlice.actions;
+export default consoleSlice.reducer;

--- a/frontend/src/features/services/servicesData.js
+++ b/frontend/src/features/services/servicesData.js
@@ -1,0 +1,1587 @@
+
+const servicesData = [
+  {
+    key: 'hl7-parser',
+    name: 'HL7 Parser Service',
+    baseUrl: '/api/v1/hl7-parser',
+    description: 'Transforms HL7 v2 messages into FHIR resources with validation and Kafka fan-out.',
+    endpoints: [
+      {
+        id: 'hl7-ingest',
+        name: 'HL7 Message Ingestion',
+        method: 'POST',
+        path: '/ingest',
+        summary: 'Accepts an HL7 ADT message and returns correlated FHIR resources.',
+        requestHeaders: [
+          { key: 'Content-Type', value: 'application/hl7-v2' },
+          { key: 'Authorization', value: 'Bearer {jwt_token}' }
+        ],
+        requestPayload: `MSH|^~\\&|SENDING_APP|SENDING_FACILITY|RECEIVING_APP|RECEIVING_FACILITY|20230901123045||ADT^A0\nEVN||20230901123045|||USER123\nPID|||MRN12345||Doe^John^M||19800115|M|||123 Main St^^City^ST^12345^USA||5551234567|\nPV1||I|ICU^101^A|||DOC123^Smith^Jane^MD|||SUR||||A|||DOC123|INS|12345|||||||||||||||||||20230901123045`,
+        responsePayload: `{
+  "messageId": "MSG001",
+  "correlationId": "corr-uuid-123",
+  "status": "processed",
+  "timestamp": "2023-09-01T12:30:45Z",
+  "fhirResources": [
+    {
+      "resourceType": "Patient",
+      "id": "patient-12345",
+      "identifier": [{ "value": "MRN12345" }],
+      "name": [{ "family": "Doe", "given": ["John"] }]
+    }
+  ],
+  "errors": []
+}`,
+        validationRules: [
+          'MSH segment must be present',
+          'Message Control ID must be unique',
+          'Sending/Receiving applications must be registered',
+          'HL7 version must be 2.3–2.8'
+        ],
+        kafkaEvents: ['hl7.message.received', 'fhir.resource.created']
+      },
+      {
+        id: 'hl7-parse-status',
+        name: 'Message Parsing Status',
+        method: 'GET',
+        path: '/parse-status/{messageId}',
+        summary: 'Retrieves the processing progress for a specific HL7 message.',
+        responsePayload: `{
+  "messageId": "MSG001",
+  "status": "completed",
+  "processedAt": "2023-09-01T12:30:45Z",
+  "resourcesCreated": 3,
+  "errors": []
+}`,
+        validationRules: ['Message must exist', 'Caller must have access to audit trail']
+      },
+      {
+        id: 'hl7-batch',
+        name: 'Batch Processing',
+        method: 'POST',
+        path: '/batch',
+        summary: 'Submit a batch of HL7 messages for prioritised processing.',
+        requestPayload: `{
+  "batchId": "batch-001",
+  "messages": [
+    {
+      "messageId": "MSG001",
+      "content": "MSH|^~\\&|...",
+      "priority": "normal"
+    }
+  ]
+}`,
+        responsePayload: `{
+  "batchId": "batch-001",
+  "totalMessages": 10,
+  "processed": 8,
+  "failed": 2,
+  "processingTime": "45.2s",
+  "status": "partial_success"
+}`
+      }
+    ]
+  },
+  {
+    key: 'patients',
+    name: 'Patient Service',
+    baseUrl: '/api/v1/patients',
+    description: 'Manages patient demographics, merges, exports and search.',
+    endpoints: [
+      {
+        id: 'patient-registration',
+        name: 'Patient Registration',
+        method: 'POST',
+        path: '/',
+        summary: 'Registers a patient using a FHIR Patient resource.',
+        requestHeaders: [
+          { key: 'Content-Type', value: 'application/fhir+json' },
+          { key: 'Authorization', value: 'Bearer {jwt_token}' }
+        ],
+        requestPayload: `{
+  "resourceType": "Patient",
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR"
+          }
+        ]
+      },
+      "value": "MRN12345"
+    }
+  ],
+  "name": [
+    {
+      "use": "official",
+      "family": "Doe",
+      "given": ["John", "Michael"]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1980-01-15",
+  "address": [
+    {
+      "use": "home",
+      "line": ["123 Main St"],
+      "city": "Springfield",
+      "state": "IL",
+      "postalCode": "62701",
+      "country": "US"
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "555-123-4567",
+      "use": "mobile"
+    },
+    {
+      "system": "email",
+      "value": "john.doe@email.com"
+    }
+  ]
+}`,
+        responsePayload: `{
+  "resourceType": "Patient",
+  "id": "patient-uuid-123",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-09-01T12:30:45Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR"
+          }
+        ]
+      },
+      "value": "MRN12345"
+    }
+  ],
+  "name": [
+    {
+      "use": "official",
+      "family": "Doe",
+      "given": ["John", "Michael"]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1980-01-15"
+}`,
+        validationRules: [
+          'At least one identifier required',
+          'Valid email format if provided',
+          'Phone number format validation',
+          'Birth date cannot be in the future',
+          'Gender must be from ValueSet',
+          'Required fields: name, gender, birthDate'
+        ],
+        kafkaEvents: ['patient.registered', 'audit.patient.created']
+      },
+      {
+        id: 'patient-update',
+        name: 'Patient Profile Update',
+        method: 'PUT',
+        path: '/{patientId}',
+        summary: 'Updates an existing patient record with auditing.',
+        validationRules: ['Patient must exist', 'User must have permission to update', 'Audit trail required for all changes']
+      },
+      {
+        id: 'patient-search',
+        name: 'Patient Search',
+        method: 'GET',
+        path: '/search',
+        summary: 'Searches for patients using demographic criteria.',
+        queryParameters: ['identifier', 'name', 'birthdate', 'phone', 'email', '_fuzzy'],
+        responsePayload: `{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 1,
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "patient-uuid-123",
+        "name": [{ "family": "Doe", "given": ["John"] }]
+      }
+    }
+  ]
+}`
+      },
+      {
+        id: 'patient-merge',
+        name: 'Patient Record Merge',
+        method: 'POST',
+        path: '/{sourceId}/merge/{targetId}',
+        summary: 'Consolidates duplicate patient records with audit capture.',
+        requestPayload: `{
+  "reason": "Duplicate records identified",
+  "mergeStrategy": "keep_latest",
+  "fields": ["contact", "address"],
+  "auditReason": "Data quality improvement"
+}`,
+        responsePayload: `{
+  "status": "merged",
+  "resultPatientId": "patient-uuid-123",
+  "mergedFields": ["telecom", "address"],
+  "auditId": "audit-uuid-456"
+}`
+      },
+      {
+        id: 'patient-export',
+        name: 'Data Export',
+        method: 'GET',
+        path: '/{patientId}/export',
+        summary: 'Exports longitudinal patient data in multiple formats.',
+        queryParameters: ['format=pdf|fhir|cda', 'includeSections=demographics,vitals,labs,medications'],
+        responsePayload: `{
+  "exportId": "export-uuid-789",
+  "status": "completed",
+  "downloadUrl": "/api/v1/exports/export-uuid-789/download",
+  "format": "pdf",
+  "size": "2.4MB",
+  "expiresAt": "2023-09-08T12:30:45Z"
+}`
+      }
+    ]
+  },
+  {
+    key: 'observations',
+    name: 'Observation Service',
+    baseUrl: '/api/v1/observations',
+    description: 'Captures vitals, labs, and analytics-ready observation trends.',
+    endpoints: [
+      {
+        id: 'observation-vital-signs',
+        name: 'Vital Signs Entry',
+        method: 'POST',
+        path: '/',
+        summary: 'Records a vital sign observation with UCUM-compliant units.',
+        requestPayload: `{
+  "resourceType": "Observation",
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "vital-signs"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "85354-9",
+        "display": "Blood pressure panel with all children optional"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/patient-uuid-123"
+  },
+  "effectiveDateTime": "2023-09-01T12:30:45Z",
+  "component": [
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "http://loinc.org",
+            "code": "8480-6",
+            "display": "Systolic blood pressure"
+          }
+        ]
+      },
+      "valueQuantity": {
+        "value": 120,
+        "unit": "mmHg",
+        "system": "http://unitsofmeasure.org",
+        "code": "mm[Hg]"
+      }
+    }
+  ]
+}`,
+        responsePayload: `{
+  "resourceType": "Observation",
+  "id": "obs-uuid-123",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-09-01T12:30:45Z"
+  },
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "vital-signs"
+        }
+      ]
+    }
+  ]
+}`,
+        validationRules: [
+          'LOINC codes must be valid',
+          'Units must be UCUM compliant',
+          'Vital sign ranges validation',
+          'Patient reference must exist',
+          'Effective date cannot be in future'
+        ],
+        kafkaEvents: ['observation.created', 'alert.triggered', 'trend.calculated']
+      },
+      {
+        id: 'observation-lab-results',
+        name: 'Lab Results Integration',
+        method: 'POST',
+        path: '/lab-results',
+        summary: 'Bundles laboratory observations in a transaction.',
+        requestPayload: `{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "POST",
+        "url": "Observation"
+      },
+      "resource": {
+        "resourceType": "Observation",
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2339-0",
+              "display": "Glucose"
+            }
+          ]
+        },
+        "valueQuantity": {
+          "value": 95,
+          "unit": "mg/dL",
+          "system": "http://unitsofmeasure.org"
+        }
+      }
+    }
+  ]
+}`
+      },
+      {
+        id: 'observation-trends',
+        name: 'Trend Visualization Data',
+        method: 'GET',
+        path: '/{patientId}/trends',
+        summary: 'Calculates longitudinal trend data for a given patient and metric.',
+        queryParameters: ['code', 'category', 'period'],
+        responsePayload: `{
+  "patientId": "patient-uuid-123",
+  "observationType": "glucose",
+  "unit": "mg/dL",
+  "timeRange": {
+    "start": "2023-08-01T00:00:00Z",
+    "end": "2023-09-01T00:00:00Z"
+  },
+  "dataPoints": [
+    { "timestamp": "2023-08-01T08:00:00Z", "value": 95, "status": "normal" },
+    { "timestamp": "2023-08-15T08:00:00Z", "value": 110, "status": "high" }
+  ],
+  "referenceRanges": {
+    "low": 70,
+    "high": 100
+  }
+}`
+      },
+      {
+        id: 'observation-alerts',
+        name: 'Clinical Alerts',
+        method: 'POST',
+        path: '/alerts/configure',
+        summary: 'Configures personalised notification thresholds for observations.',
+        requestPayload: `{
+  "patientId": "patient-uuid-123",
+  "observationCode": "8480-6",
+  "thresholds": {
+    "critical": {
+      "high": 180,
+      "low": 90
+    },
+    "warning": {
+      "high": 140,
+      "low": 100
+    }
+  },
+  "notificationChannels": ["email", "sms", "app"],
+  "active": true
+}`,
+        kafkaEvents: ['observation.created', 'alert.triggered', 'trend.calculated']
+      }
+    ]
+  },
+  {
+    key: 'appointments',
+    name: 'Appointment Service',
+    baseUrl: '/api/v1/appointments',
+    description: 'Handles booking, availability, and waitlist orchestration.',
+    endpoints: [
+      {
+        id: 'appointment-booking',
+        name: 'Appointment Booking',
+        method: 'POST',
+        path: '/',
+        summary: 'Schedules a practitioner appointment with confirmation metadata.',
+        requestPayload: `{
+  "resourceType": "Appointment",
+  "status": "booked",
+  "serviceCategory": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/service-category",
+          "code": "17",
+          "display": "General Practice"
+        }
+      ]
+    }
+  ],
+  "appointmentType": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v2-0276",
+        "code": "ROUTINE"
+      }
+    ]
+  },
+  "start": "2023-09-15T09:00:00Z",
+  "end": "2023-09-15T09:30:00Z",
+  "participant": [
+    {
+      "actor": {
+        "reference": "Patient/patient-uuid-123"
+      },
+      "required": "required",
+      "status": "accepted"
+    },
+    {
+      "actor": {
+        "reference": "Practitioner/doc-uuid-456"
+      },
+      "required": "required",
+      "status": "accepted"
+    }
+  ]
+}`,
+        responsePayload: `{
+  "resourceType": "Appointment",
+  "id": "appt-uuid-789",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-09-01T12:30:45Z"
+  },
+  "status": "booked",
+  "start": "2023-09-15T09:00:00Z",
+  "end": "2023-09-15T09:30:00Z",
+  "confirmationCode": "CONF123456"
+}`,
+        validationRules: [
+          'Start time must be in future',
+          'End time must be after start time',
+          'Practitioner must be available',
+          'Patient cannot have overlapping appointments',
+          'Business hours validation'
+        ],
+        kafkaEvents: ['appointment.booked', 'appointment.cancelled', 'waitlist.added']
+      },
+      {
+        id: 'appointment-availability',
+        name: 'Real-time Availability',
+        method: 'GET',
+        path: '/availability',
+        summary: 'Displays open appointment slots for a practitioner.',
+        queryParameters: ['practitioner', 'date', 'duration', 'serviceType'],
+        responsePayload: `{
+  "date": "2023-09-15",
+  "practitioner": "doc-uuid-456",
+  "availableSlots": [
+    { "start": "2023-09-15T09:00:00Z", "end": "2023-09-15T09:30:00Z", "type": "available" },
+    { "start": "2023-09-15T10:00:00Z", "end": "2023-09-15T10:30:00Z", "type": "tentative" }
+  ]
+}`
+      },
+      {
+        id: 'appointment-waitlist',
+        name: 'Waitlist Management',
+        method: 'POST',
+        path: '/{appointmentId}/waitlist',
+        summary: 'Registers a patient for waitlist notifications.',
+        requestPayload: `{
+  "patientId": "patient-uuid-123",
+  "preferredDates": ["2023-09-15", "2023-09-16"],
+  "preferredTimes": ["morning", "afternoon"],
+  "priority": "routine",
+  "notificationPreferences": {
+    "email": true,
+    "sms": true,
+    "advanceNotice": "24h"
+  }
+}`
+      }
+    ]
+  },
+  {
+    key: 'auth',
+    name: 'User Auth Service',
+    baseUrl: '/api/v1/auth',
+    description: 'Handles login, registration, password resets, and MFA.',
+    endpoints: [
+      {
+        id: 'auth-login',
+        name: 'User Login',
+        method: 'POST',
+        path: '/login',
+        summary: 'Authenticates a user with MFA and device metadata.',
+        requestPayload: `{
+  "username": "john.doe@example.com",
+  "password": "SecurePass123!",
+  "mfaCode": "123456",
+  "deviceInfo": {
+    "deviceId": "device-uuid-123",
+    "userAgent": "Mozilla/5.0...",
+    "ipAddress": "192.168.1.100"
+  }
+}`,
+        responsePayload: `{
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "refreshToken": "refresh-token-uuid",
+  "tokenType": "Bearer",
+  "expiresIn": 3600,
+  "user": {
+    "id": "user-uuid-123",
+    "email": "john.doe@example.com",
+    "roles": ["patient"],
+    "permissions": ["read:own_records", "write:own_profile"]
+  }
+}`,
+        validationRules: [
+          'Email format validation',
+          'Password complexity requirements',
+          'Rate limiting: 5 attempts per 15 minutes',
+          'MFA required for privileged accounts',
+          'Device registration for new devices'
+        ],
+        kafkaEvents: ['user.authenticated', 'security.failed_login']
+      },
+      {
+        id: 'auth-register',
+        name: 'User Registration',
+        method: 'POST',
+        path: '/register',
+        summary: 'Registers a new patient portal user with verification.',
+        requestPayload: `{
+  "email": "john.doe@example.com",
+  "password": "SecurePass123!",
+  "confirmPassword": "SecurePass123!",
+  "profile": {
+    "firstName": "John",
+    "lastName": "Doe",
+    "phone": "555-123-4567",
+    "dateOfBirth": "1980-01-15"
+  },
+  "acceptTerms": true,
+  "verificationMethod": "email"
+}`
+      },
+      {
+        id: 'auth-password-reset',
+        name: 'Password Reset',
+        method: 'POST',
+        path: '/password-reset',
+        summary: 'Initiates a password reset workflow.',
+        requestPayload: `{
+  "email": "john.doe@example.com",
+  "resetMethod": "email"
+}`,
+        responsePayload: `{
+  "status": "sent",
+  "message": "Password reset instructions sent to email",
+  "resetTokenId": "reset-uuid-123",
+  "expiresIn": 3600
+}`
+      },
+      {
+        id: 'auth-mfa',
+        name: 'Multi-Factor Authentication Setup',
+        method: 'POST',
+        path: '/mfa/setup',
+        summary: 'Configures TOTP MFA devices for a user.',
+        requestPayload: `{
+  "method": "totp",
+  "deviceName": "iPhone 12"
+}`,
+        responsePayload: `{
+  "qrCode": "data:image/png;base64,iVBOR...",
+  "secret": "JBSWY3DPEHPK3PXP",
+  "backupCodes": ["12345678", "87654321"]
+}`,
+        kafkaEvents: ['user.registered', 'user.authenticated']
+      }
+    ]
+  },
+  {
+    key: 'roles',
+    name: 'Role Management Service',
+    baseUrl: '/api/v1/roles',
+    description: 'Manages RBAC/ABAC assignments and permission evaluations.',
+    endpoints: [
+      {
+        id: 'roles-assign',
+        name: 'Role Assignment',
+        method: 'POST',
+        path: '/assign',
+        summary: 'Assigns one or more roles to a user with temporal bounds.',
+        requestPayload: `{
+  "userId": "user-uuid-123",
+  "roles": ["doctor", "department_head"],
+  "effectiveDate": "2023-09-01T00:00:00Z",
+  "expiryDate": "2024-09-01T00:00:00Z",
+  "assignedBy": "admin-uuid-456",
+  "reason": "Promotion to department head"
+}`,
+        responsePayload: `{
+  "assignmentId": "assignment-uuid-789",
+  "status": "active",
+  "permissions": [
+    "read:patient_records",
+    "write:observations",
+    "manage:department_users"
+  ],
+  "effectiveDate": "2023-09-01T00:00:00Z"
+}`
+      },
+      {
+        id: 'roles-validate',
+        name: 'Permission Validation',
+        method: 'POST',
+        path: '/validate',
+        summary: 'Evaluates a user's permission for a specific resource action.',
+        requestPayload: `{
+  "userId": "user-uuid-123",
+  "resource": "Patient/patient-uuid-456",
+  "action": "read",
+  "context": {
+    "facility": "facility-uuid-789",
+    "department": "cardiology"
+  }
+}`,
+        responsePayload: `{
+  "allowed": true,
+  "decision": "permit",
+  "reason": "User has doctor role with read permission",
+  "conditions": ["audit_required", "time_limited"]
+}`
+      },
+      {
+        id: 'roles-abac',
+        name: 'Attribute-Based Access Control',
+        method: 'POST',
+        path: '/abac/evaluate',
+        summary: 'Evaluates fine-grained ABAC policies for a subject and resource.',
+        requestPayload: `{
+  "subject": {
+    "userId": "user-uuid-123",
+    "roles": ["doctor"],
+    "department": "cardiology",
+    "facility": "facility-uuid-789"
+  },
+  "resource": {
+    "type": "Patient",
+    "id": "patient-uuid-456",
+    "attributes": {
+      "facility": "facility-uuid-789",
+      "department": "cardiology"
+    }
+  },
+  "action": "read",
+  "environment": {
+    "time": "2023-09-01T14:30:00Z",
+    "location": "clinic"
+  }
+}`,
+        kafkaEvents: ['role.assigned', 'permission.denied', 'access.granted']
+      }
+    ]
+  },
+  {
+    key: 'telemedicine',
+    name: 'Telemedicine Service',
+    baseUrl: '/api/v1/telemedicine',
+    description: 'Coordinates virtual visit sessions and consent tracking.',
+    endpoints: [
+      {
+        id: 'telemedicine-session',
+        name: 'Session Creation',
+        method: 'POST',
+        path: '/sessions',
+        summary: 'Creates a secure telemedicine session and join URLs.',
+        requestPayload: `{
+  "appointmentId": "appt-uuid-789",
+  "participants": [
+    { "userId": "patient-uuid-123", "role": "patient" },
+    { "userId": "doc-uuid-456", "role": "provider" }
+  ],
+  "sessionType": "video_consultation",
+  "scheduledStart": "2023-09-15T09:00:00Z",
+  "estimatedDuration": 30
+}`,
+        responsePayload: `{
+  "sessionId": "session-uuid-101",
+  "joinUrls": {
+    "patient": "https://telemedicine.example.com/join/patient-token-123",
+    "provider": "https://telemedicine.example.com/join/provider-token-456"
+  },
+  "accessWindow": {
+    "start": "2023-09-15T08:50:00Z",
+    "end": "2023-09-15T09:40:00Z"
+  },
+  "sessionSettings": {
+    "recordingEnabled": false,
+    "chatEnabled": true,
+    "screenShareEnabled": true
+  }
+}`,
+        kafkaEvents: ['session.started', 'session.ended']
+      },
+      {
+        id: 'telemedicine-consent',
+        name: 'Consent Management',
+        method: 'POST',
+        path: '/consent',
+        summary: 'Captures explicit consent for telemedicine features.',
+        requestPayload: `{
+  "sessionId": "session-uuid-101",
+  "userId": "patient-uuid-123",
+  "consentType": "video_recording",
+  "granted": true,
+  "timestamp": "2023-09-15T08:55:00Z",
+  "ipAddress": "192.168.1.100"
+}`,
+        kafkaEvents: ['consent.recorded']
+      },
+      {
+        id: 'telemedicine-metrics',
+        name: 'Quality Monitoring',
+        method: 'GET',
+        path: '/sessions/{sessionId}/metrics',
+        summary: 'Reports call quality metrics for compliance review.',
+        responsePayload: `{
+  "sessionId": "session-uuid-101",
+  "qualityMetrics": {
+    "averageLatency": 45,
+    "packetLoss": 0.2,
+    "videoQuality": "HD",
+    "audioQuality": "excellent"
+  },
+  "duration": 1800,
+  "participants": [
+    {
+      "userId": "patient-uuid-123",
+      "connectionTime": 1795,
+      "disconnections": 0
+    }
+  ]
+}`
+      }
+    ]
+  },
+  {
+    key: 'notifications',
+    name: 'Notification Service',
+    baseUrl: '/api/v1/notifications',
+    description: 'Manages multichannel notifications and templates.',
+    endpoints: [
+      {
+        id: 'notifications-send',
+        name: 'Send Notification',
+        method: 'POST',
+        path: '/send',
+        summary: 'Queues notifications across multiple channels.',
+        requestPayload: `{
+  "recipientId": "user-uuid-123",
+  "channels": ["email", "sms"],
+  "template": "appointment_reminder",
+  "data": {
+    "appointmentDate": "2023-09-15T09:00:00Z",
+    "doctorName": "Dr. Jane Smith",
+    "location": "Room 101, Main Building"
+  },
+  "scheduledAt": "2023-09-14T20:00:00Z",
+  "priority": "normal"
+}`,
+        responsePayload: `{
+  "notificationId": "notif-uuid-123",
+  "status": "scheduled",
+  "channels": [
+    { "type": "email", "status": "queued", "estimatedDelivery": "2023-09-14T20:00:30Z" },
+    { "type": "sms", "status": "queued", "estimatedDelivery": "2023-09-14T20:00:15Z" }
+  ]
+}`,
+        kafkaEvents: ['notification.sent', 'notification.failed', 'notification.delivered']
+      },
+      {
+        id: 'notifications-template',
+        name: 'Template Management',
+        method: 'POST',
+        path: '/templates',
+        summary: 'Creates or updates reusable notification templates.',
+        requestPayload: `{
+  "name": "appointment_reminder",
+  "channels": {
+    "email": {
+      "subject": "Appointment Reminder - {{appointmentDate}}",
+      "body": "Dear {{patientName}}, you have an appointment with {{doctorName}} on {{appointmentDate}}."
+    },
+    "sms": {
+      "body": "Reminder: Appointment with {{doctorName}} on {{appointmentDate}}. Reply STOP to opt out."
+    }
+  },
+  "variables": ["patientName", "doctorName", "appointmentDate"]
+}`
+      },
+      {
+        id: 'notifications-bulk',
+        name: 'Bulk Notification',
+        method: 'POST',
+        path: '/bulk',
+        summary: 'Launches a campaign to multiple recipients.',
+        requestPayload: `{
+  "campaignName": "flu_shot_reminder",
+  "template": "vaccination_reminder",
+  "recipients": [
+    { "userId": "user-uuid-123", "data": { "patientName": "John Doe" } },
+    { "userId": "user-uuid-456", "data": { "patientName": "Jane Smith" } }
+  ],
+  "channels": ["email"],
+  "scheduledAt": "2023-09-20T10:00:00Z"
+}`
+      }
+    ]
+  },
+  {
+    key: 'analytics',
+    name: 'Analytics Service',
+    baseUrl: '/api/v1/analytics',
+    description: 'Provides risk scoring, ML lifecycle, and operational insights.',
+    endpoints: [
+      {
+        id: 'analytics-risk-score',
+        name: 'Risk Scoring',
+        method: 'POST',
+        path: '/risk-score',
+        summary: 'Calculates condition-specific risk for a patient.',
+        requestPayload: `{
+  "patientId": "patient-uuid-123",
+  "riskType": "diabetes",
+  "factors": [
+    { "type": "observation", "code": "33747-0", "value": 95, "unit": "mg/dL" },
+    { "type": "demographic", "age": 43, "gender": "male", "bmi": 28.5 }
+  ]
+}`,
+        responsePayload: `{
+  "patientId": "patient-uuid-123",
+  "riskType": "diabetes",
+  "score": 0.75,
+  "level": "high",
+  "confidence": 0.89,
+  "factors": [
+    { "name": "BMI", "contribution": 0.35, "weight": "high" },
+    { "name": "Family History", "contribution": 0.25, "weight": "medium" }
+  ],
+  "recommendations": [
+    "Regular glucose monitoring",
+    "Dietary consultation"
+  ],
+  "calculatedAt": "2023-09-01T12:30:45Z"
+}`,
+        validationRules: [
+          'Minimum dataset size: 1000 records',
+          'Feature correlation analysis required',
+          'Data quality validation mandatory',
+          'Privacy compliance verification',
+          'Model interpretability assessment'
+        ],
+        kafkaEvents: ['risk.calculated']
+      },
+      {
+        id: 'analytics-ml-train',
+        name: 'ML Model Training Pipeline',
+        method: 'POST',
+        path: '/ml/models/train',
+        summary: 'Configures and starts a machine learning training job.',
+        requestPayload: `{
+  "trainingJob": {
+    "modelName": "diabetes_risk_classifier",
+    "modelType": "classification",
+    "algorithm": "random_forest",
+    "targetVariable": "diabetes_diagnosis",
+    "features": [
+      {
+        "name": "age",
+        "type": "numeric",
+        "source": "Patient.birthDate",
+        "preprocessing": "age_calculation"
+      },
+      {
+        "name": "bmi",
+        "type": "numeric",
+        "source": "Observation",
+        "loincCode": "39156-5",
+        "preprocessing": "outlier_removal"
+      },
+      {
+        "name": "glucose_level",
+        "type": "numeric",
+        "source": "Observation",
+        "loincCode": "2339-0",
+        "aggregation": "latest_value"
+      },
+      {
+        "name": "family_history",
+        "type": "categorical",
+        "source": "FamilyMemberHistory",
+        "valueSet": "diabetes_conditions"
+      }
+    ],
+    "trainingParameters": {
+      "dataRange": {
+        "start": "2020-01-01",
+        "end": "2023-08-31"
+      },
+      "validationSplit": 0.2,
+      "testSplit": 0.1,
+      "hyperparameters": {
+        "n_estimators": 100,
+        "max_depth": 10,
+        "min_samples_split": 5,
+        "random_state": 42
+      },
+      "crossValidation": {
+        "folds": 5,
+        "stratified": true
+      }
+    },
+    "dataPrivacy": {
+      "anonymization": "k_anonymity",
+      "k_value": 5,
+      "excludePII": true,
+      "auditRequired": true
+    }
+  }
+}`,
+        responsePayload: `{
+  "trainingJobId": "job-uuid-123",
+  "status": "running",
+  "estimatedCompletion": "2023-09-01T14:30:45Z",
+  "datasetInfo": {
+    "totalRecords": 15420,
+    "trainingRecords": 12336,
+    "validationRecords": 1542,
+    "testRecords": 1542,
+    "featureCount": 15,
+    "classDistribution": {
+      "diabetes": 0.23,
+      "pre_diabetes": 0.31,
+      "normal": 0.46
+    }
+  },
+  "progress": {
+    "currentStep": "feature_engineering",
+    "completionPercent": 25,
+    "estimatedTimeRemaining": "PT45M"
+  }
+}`,
+        validationRules: [
+          'Minimum dataset size: 1000 records',
+          'Feature correlation analysis required',
+          'Data quality validation mandatory',
+          'Privacy compliance verification',
+          'Model interpretability assessment'
+        ],
+        kafkaEvents: ['model.trained']
+      },
+      {
+        id: 'analytics-ml-alerts',
+        name: 'Personalized Clinical Alerts',
+        method: 'POST',
+        path: '/ml/alerts/personalized',
+        summary: 'Creates AI-driven alert configurations with contextual factors.',
+        requestPayload: `{
+  "patientId": "patient-uuid-123",
+  "modelId": "model-uuid-456",
+  "alertConfiguration": {
+    "riskThreshold": 0.75,
+    "alertTypes": ["high_risk", "trend_deterioration"],
+    "timeHorizon": "P30D",
+    "updateFrequency": "daily"
+  },
+  "contextualFactors": [
+    {
+      "type": "recent_observations",
+      "lookbackPeriod": "P7D",
+      "weight": 0.4
+    },
+    {
+      "type": "medication_adherence",
+      "source": "MedicationStatement",
+      "weight": 0.3
+    },
+    {
+      "type": "lifestyle_factors",
+      "source": "Observation",
+      "categories": ["exercise", "diet", "smoking"],
+      "weight": 0.3
+    }
+  ]
+}`,
+        responsePayload: `{
+  "alertId": "alert-uuid-789",
+  "patientId": "patient-uuid-123",
+  "riskAssessment": {
+    "overallRisk": 0.82,
+    "riskLevel": "high",
+    "confidence": 0.89,
+    "prediction": {
+      "condition": "type_2_diabetes",
+      "probability": 0.82,
+      "timeHorizon": "P30D"
+    }
+  },
+  "contributingFactors": [
+    {
+      "factor": "elevated_glucose",
+      "impact": 0.35,
+      "recentTrend": "increasing",
+      "lastValue": 145,
+      "referenceRange": "70-100 mg/dL"
+    },
+    {
+      "factor": "bmi",
+      "impact": 0.28,
+      "value": 32.5,
+      "category": "obese"
+    }
+  ],
+  "recommendations": [
+    {
+      "type": "clinical_action",
+      "priority": "high",
+      "action": "Schedule endocrinology consultation",
+      "reasoning": "High diabetes risk with recent glucose elevation"
+    },
+    {
+      "type": "lifestyle_intervention",
+      "priority": "medium",
+      "action": "Initiate dietary counseling",
+      "evidenceLevel": "strong"
+    }
+  ],
+  "fhirResources": [
+    {
+      "resourceType": "RiskAssessment",
+      "id": "risk-assess-uuid-101",
+      "status": "final"
+    }
+  ]
+}`,
+        kafkaEvents: ['alert.generated']
+      },
+      {
+        id: 'analytics-model-version',
+        name: 'Model Versioning and Lifecycle',
+        method: 'POST',
+        path: '/ml/models/{modelId}/versions',
+        summary: 'Publishes a new model version with deployment metadata.',
+        requestPayload: `{
+  "versionInfo": {
+    "version": "2.1.0",
+    "description": "Improved diabetes risk model with additional lifestyle factors",
+    "trainingJobId": "job-uuid-123",
+    "baselineModel": "model-uuid-456-v2.0.0"
+  },
+  "performanceMetrics": {
+    "accuracy": 0.89,
+    "precision": 0.87,
+    "recall": 0.91,
+    "f1Score": 0.89,
+    "auc": 0.94,
+    "crossValidationScore": 0.88
+  },
+  "modelArtifacts": {
+    "modelFile": "diabetes_rf_v2.1.0.pkl",
+    "featureImportance": "feature_importance_v2.1.0.json",
+    "preprocessor": "preprocessor_v2.1.0.pkl",
+    "metadata": "model_metadata_v2.1.0.json"
+  },
+  "deploymentConfig": {
+    "environment": "production",
+    "rolloutStrategy": "blue_green",
+    "canaryPercentage": 10,
+    "monitoringPeriod": "P7D"
+  }
+}`,
+        responsePayload: `{
+  "modelVersionId": "model-version-uuid-456",
+  "status": "deployed",
+  "deploymentTimestamp": "2023-09-01T12:30:45Z",
+  "performanceComparison": {
+    "previousVersion": {
+      "version": "2.0.0",
+      "accuracy": 0.85,
+      "auc": 0.91
+    },
+    "improvement": {
+      "accuracy": 0.04,
+      "auc": 0.03,
+      "statisticalSignificance": true
+    }
+  },
+  "productionMetrics": {
+    "predictionLatency": "PT0.05S",
+    "throughput": "1000/minute",
+    "errorRate": 0.001
+  }
+}`
+      },
+      {
+        id: 'analytics-trends',
+        name: 'Healthcare Trend Analysis',
+        method: 'GET',
+        path: '/analytics/trends',
+        summary: 'Generates longitudinal KPI dashboards with demographic breakdowns.',
+        queryParameters: ['metric', 'timeRange', 'granularity', 'demographics', 'facility'],
+        responsePayload: `{
+  "analysisId": "trend-analysis-uuid-789",
+  "timeRange": {
+    "start": "2022-09-01T00:00:00Z",
+    "end": "2023-09-01T00:00:00Z"
+  },
+  "trends": [
+    {
+      "metric": "readmission_rate",
+      "overall": {
+        "currentValue": 0.12,
+        "previousPeriod": 0.15,
+        "changePercent": -20.0,
+        "trend": "decreasing",
+        "significance": "p < 0.05"
+      },
+      "byDemographics": [
+        { "segment": "age_65_plus", "value": 0.18, "trend": "stable", "sampleSize": 1247 },
+        { "segment": "cardiology_dept", "value": 0.08, "trend": "decreasing", "sampleSize": 892 }
+      ],
+      "timeSeriesData": [
+        { "period": "2022-09", "value": 0.15, "confidenceInterval": [0.13, 0.17] },
+        { "period": "2023-08", "value": 0.12, "confidenceInterval": [0.10, 0.14] }
+      ]
+    }
+  ],
+  "correlations": [
+    {
+      "metric1": "readmission_rate",
+      "metric2": "average_length_of_stay",
+      "correlation": -0.65,
+      "significance": "p < 0.001"
+    }
+  ],
+  "anomalies": [
+    {
+      "metric": "infection_rate",
+      "period": "2023-06",
+      "value": 0.08,
+      "expected": 0.05,
+      "zScore": 2.3,
+      "investigation": "required"
+    }
+  ]
+}`
+      },
+      {
+        id: 'analytics-link-fhir',
+        name: 'FHIR Resource Linking for Predictions',
+        method: 'POST',
+        path: '/ml/predictions/link-fhir',
+        summary: 'Anchors ML predictions to canonical FHIR resources.',
+        requestPayload: `{
+  "predictionId": "prediction-uuid-123",
+  "patientId": "patient-uuid-456",
+  "modelId": "model-uuid-789",
+  "fhirMapping": {
+    "primaryResource": {
+      "resourceType": "RiskAssessment",
+      "method": {
+        "coding": [
+          {
+            "system": "http://example.org/ml-models",
+            "code": "diabetes_risk_rf_v2.1.0",
+            "display": "Diabetes Risk Random Forest v2.1.0"
+          }
+        ]
+      },
+      "prediction": [
+        {
+          "outcome": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "44054006",
+                "display": "Type 2 diabetes mellitus"
+              }
+            ]
+          },
+          "probabilityDecimal": 0.82,
+          "whenRange": {
+            "low": { "value": 30, "unit": "d" },
+            "high": { "value": 90, "unit": "d" }
+          }
+        }
+      ],
+      "supportingResources": [
+        {
+          "resourceType": "DetectedIssue",
+          "status": "final",
+          "category": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "code": "CAUTION"
+              }
+            ]
+          },
+          "detail": "High risk for developing diabetes based on current health indicators"
+        }
+      ]
+    }
+  }
+}`,
+        responsePayload: `{
+  "linkingId": "fhir-link-uuid-101",
+  "fhirResources": [
+    {
+      "resourceType": "RiskAssessment",
+      "id": "risk-assess-uuid-202",
+      "status": "final",
+      "subject": { "reference": "Patient/patient-uuid-456" },
+      "performer": { "reference": "Device/ml-model-device-uuid-303" },
+      "prediction": [
+        {
+          "outcome": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "44054006",
+                "display": "Type 2 diabetes mellitus"
+              }
+            ]
+          },
+          "probabilityDecimal": 0.82
+        }
+      ]
+    }
+  ],
+  "auditTrail": {
+    "createdBy": "ml-system",
+    "createdAt": "2023-09-01T12:30:45Z",
+    "modelVersion": "2.1.0",
+    "inputFeatures": 15,
+    "confidence": 0.89
+  }
+}`
+      }
+    ]
+  },
+  {
+    key: 'audit',
+    name: 'Audit Logging Service',
+    baseUrl: '/api/v1/audit',
+    description: 'Captures immutable audit events, exports, and anomaly detection.',
+    endpoints: [
+      {
+        id: 'audit-log-event',
+        name: 'Log Access Event',
+        method: 'POST',
+        path: '/events',
+        summary: 'Writes a tamper-evident access log entry.',
+        requestPayload: `{
+  "eventType": "data_access",
+  "userId": "user-uuid-123",
+  "resourceType": "Patient",
+  "resourceId": "patient-uuid-456",
+  "action": "read",
+  "timestamp": "2023-09-01T12:30:45Z",
+  "sessionId": "session-uuid-789",
+  "ipAddress": "192.168.1.100",
+  "userAgent": "Mozilla/5.0...",
+  "metadata": {
+    "reason": "Patient consultation",
+    "department": "cardiology",
+    "facility": "facility-uuid-001"
+  }
+}`,
+        responsePayload: `{
+  "auditId": "audit-uuid-123",
+  "status": "logged",
+  "timestamp": "2023-09-01T12:30:45Z",
+  "immutableHash": "sha256:abc123def456..."
+}`,
+        kafkaEvents: ['audit.logged', 'audit.anomaly_detected']
+      },
+      {
+        id: 'audit-export',
+        name: 'Export Audit Logs',
+        method: 'GET',
+        path: '/export',
+        summary: 'Exports audit trail data for compliance review.',
+        queryParameters: ['startDate', 'endDate', 'userId', 'resourceType', 'format'],
+        responsePayload: `{
+  "exportId": "export-uuid-456",
+  "status": "processing",
+  "format": "csv",
+  "downloadUrl": "/api/v1/audit/exports/export-uuid-456",
+  "estimatedCompletion": "2023-09-01T12:35:45Z",
+  "digitalSignature": "MIIC..."
+}`
+      },
+      {
+        id: 'audit-anomalies',
+        name: 'Anomaly Detection',
+        method: 'GET',
+        path: '/anomalies',
+        summary: 'Highlights anomalous access behaviour over a recent window.',
+        responsePayload: `{
+  "period": "P7D",
+  "anomalies": [
+    {
+      "type": "unusual_access_pattern",
+      "userId": "user-uuid-123",
+      "description": "Access to 50+ patient records in 1 hour",
+      "severity": "medium",
+      "timestamp": "2023-09-01T02:00:00Z",
+      "score": 0.75
+    }
+  ]
+}`
+      }
+    ]
+  },
+  {
+    key: 'fhir-gateway',
+    name: 'FHIR API Gateway',
+    baseUrl: '/fhir/R4',
+    description: 'Externalised SMART-on-FHIR gateway and metadata endpoints.',
+    endpoints: [
+      {
+        id: 'fhir-patient',
+        name: 'External FHIR Access',
+        method: 'GET',
+        path: '/Patient/{patientId}',
+        summary: 'Reads a patient resource from the external FHIR facade.',
+        requestHeaders: [{ key: 'Authorization', value: 'Bearer {api_key}' }, { key: 'Accept', value: 'application/fhir+json' }],
+        responsePayload: `{
+  "resourceType": "Patient",
+  "id": "patient-uuid-123",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-09-01T12:30:45Z"
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "value": "MRN12345"
+    }
+  ]
+}`
+      },
+      {
+        id: 'fhir-metadata',
+        name: 'Capability Statement',
+        method: 'GET',
+        path: '/metadata',
+        summary: 'Returns the capability statement for the gateway.',
+        responsePayload: `{
+  "resourceType": "CapabilityStatement",
+  "status": "active",
+  "date": "2023-09-01",
+  "publisher": "Healthcare Organization",
+  "kind": "instance",
+  "software": {
+    "name": "FHIR Patient Portal",
+    "version": "1.0.0"
+  },
+  "fhirVersion": "4.0.1",
+  "format": ["json", "xml"],
+  "rest": [
+    {
+      "mode": "server",
+      "resource": [
+        {
+          "type": "Patient",
+          "interaction": [
+            { "code": "read" },
+            { "code": "search-type" }
+          ]
+        }
+      ]
+    }
+  ]
+}`
+      },
+      {
+        id: 'fhir-batch',
+        name: 'Batch Operations',
+        method: 'POST',
+        path: '/',
+        summary: 'Performs multi-resource batch operations.',
+        requestPayload: `{
+  "resourceType": "Bundle",
+  "type": "batch",
+  "entry": [
+    {
+      "request": { "method": "GET", "url": "Patient/patient-uuid-123" }
+    },
+    {
+      "request": { "method": "GET", "url": "Observation?patient=patient-uuid-123" }
+    }
+  ]
+}`
+      }
+    ]
+  },
+  {
+    key: 'kafka',
+    name: 'Kafka Communication Patterns',
+    baseUrl: '',
+    description: 'Documented topic strategy, schemas, and operational considerations.',
+    endpoints: [
+      {
+        id: 'kafka-topics',
+        name: 'Topic Architecture',
+        method: 'DESIGN',
+        path: 'topic-architecture',
+        summary: 'Naming conventions and example topic catalogues.',
+        responsePayload: `Structure: {service}.{entity}.{action}.{version}\nExamples: patient.registered.v1, observation.created.v1, audit.logged.v1`
+      },
+      {
+        id: 'kafka-event-schema',
+        name: 'Core Event Schema',
+        method: 'DESIGN',
+        path: 'event-schema',
+        summary: 'Canonical JSON structure enforced across events.',
+        responsePayload: `{
+  "eventId": "event-uuid-123",
+  "eventType": "patient.registered.v1",
+  "eventVersion": "1.0",
+  "timestamp": "2023-09-01T12:30:45Z",
+  "source": {
+    "service": "patient-service",
+    "version": "2.1.0",
+    "instance": "patient-service-pod-3"
+  },
+  "subject": {
+    "type": "Patient",
+    "id": "patient-uuid-123",
+    "tenantId": "tenant-clinic-001"
+  },
+  "data": {
+    "action": "created",
+    "userId": "user-uuid-456",
+    "previousState": null,
+    "currentState": {
+      "status": "active",
+      "registrationComplete": true
+    }
+  },
+  "metadata": {
+    "correlationId": "corr-uuid-789",
+    "causationId": "cause-uuid-101",
+    "sessionId": "session-uuid-202",
+    "traceId": "trace-uuid-303",
+    "priority": "normal",
+    "retryCount": 0
+  },
+  "compliance": {
+    "dataClassification": "PHI",
+    "retentionPeriod": "P7Y",
+    "encryptionRequired": true,
+    "auditRequired": true
+  }
+}`
+      },
+      {
+        id: 'kafka-topic-config',
+        name: 'Topic Configurations',
+        method: 'DESIGN',
+        path: 'topic-configurations',
+        summary: 'Partitioning, retention, and compression strategies across services.',
+        responsePayload: `patient.lifecycle.v1 => partitions: 12, replication: 3, retentionMs: 604800000\nobservation.clinical.v1 => partitions: 24, compression: lz4\nsecurity.events.v1 => partitions: 16, cleanupPolicy: compact`
+      },
+      {
+        id: 'kafka-dlq',
+        name: 'Dead Letter Queue',
+        method: 'DESIGN',
+        path: 'dlq',
+        summary: 'Retry policies and alerting for failed events.',
+        responsePayload: `dlq.failed-events.v1 => partitions: 4, retentionMs: 604800000, retry max: 3, exponential backoff`
+      },
+      {
+        id: 'kafka-processing',
+        name: 'Consumer Processing Patterns',
+        method: 'DESIGN',
+        path: 'consumers',
+        summary: 'Realtime, batch, and compliance consumer archetypes.',
+        responsePayload: `patient-service-realtime => topics: hl7.message.received.v1, user.registered.v1\nnotification-service-immediate => priority queues by severity\nanalytics-service-batch => windowDuration PT5M`
+      },
+      {
+        id: 'kafka-monitoring',
+        name: 'Performance Monitoring and Alerting',
+        method: 'DESIGN',
+        path: 'monitoring',
+        summary: 'Metrics, health checks, and alert thresholds.',
+        responsePayload: `Monitor consumer_lag > 10000 for PT5M (warning)\nAlert error_rate > 0.05 for PT2M (critical)\nHealth checks: latency, lag, disk usage, replication`
+      },
+      {
+        id: 'kafka-security',
+        name: 'Security Configuration',
+        method: 'DESIGN',
+        path: 'security',
+        summary: 'Kafka ACLs, encryption, and schema registry governance.',
+        responsePayload: `Protocol: SASL_SSL (SCRAM-SHA-512)\nEncryption: TLS 1.3 in transit, AES-256-GCM at rest\nSchema Registry: BACKWARD compatibility, TopicNameStrategy`
+      }
+    ]
+  }
+];
+
+servicesData.forEach((service) => {
+  service.endpoints.forEach((endpoint) => {
+    endpoint.fullPath = `${service.baseUrl}${endpoint.path}`.replace(/\/\/$/, '/');
+  });
+});
+
+export default servicesData;

--- a/frontend/src/features/services/servicesSlice.js
+++ b/frontend/src/features/services/servicesSlice.js
@@ -1,0 +1,101 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+import { setLoading, setResponse, setError } from '../console/consoleSlice.js';
+import servicesData from './servicesData.js';
+
+export const sendServiceRequest = createAsyncThunk(
+  'services/sendRequest',
+  async ({ serviceKey, endpointKey, body, params }, { getState, dispatch, rejectWithValue }) => {
+    const {
+      config: { baseUrl, token }
+    } = getState();
+
+    const sanitizedBase = baseUrl?.replace(/\/$/, '') ?? '';
+    let urlString = endpointKey;
+    if (!/^https?:/i.test(endpointKey)) {
+      const prefix = sanitizedBase || (typeof window !== 'undefined' ? window.location.origin : '');
+      const separator = endpointKey.startsWith('/') ? '' : '/';
+      urlString = `${prefix}${separator}${endpointKey}`;
+    }
+
+    const url = new URL(urlString);
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== '') {
+          url.searchParams.append(key, value);
+        }
+      });
+    }
+
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const requestKey = `${serviceKey}${endpointKey}`;
+    dispatch(setLoading({ key: requestKey, loading: true }));
+
+    let payload;
+    if (body && body.trim()) {
+      try {
+        payload = JSON.parse(body);
+      } catch (parseError) {
+        payload = body;
+      }
+    }
+
+    try {
+      const method = inferMethod(serviceKey, endpointKey);
+      const requestConfig = {
+        method,
+        url: url.toString(),
+        headers
+      };
+
+      if (payload !== undefined && method !== 'GET') {
+        requestConfig.data = payload;
+      }
+
+      const response = await axios(requestConfig);
+      dispatch(setResponse({ key: requestKey, response: response.data, status: response.status }));
+      return response.data;
+    } catch (error) {
+      const status = error.response?.status;
+      const payload = error.response?.data ?? error.message;
+      dispatch(setError({ key: requestKey, error: payload, status }));
+      return rejectWithValue({ status, payload });
+    }
+  }
+);
+
+function inferMethod(serviceKey, endpointKey) {
+  const service = servicesData.find((item) => item.key === serviceKey);
+  if (!service) return 'GET';
+  const endpoint = service.endpoints.find((ep) => `${service.baseUrl}${ep.path}` === endpointKey || ep.fullPath === endpointKey);
+  return endpoint?.method ?? 'GET';
+}
+
+const servicesSlice = createSlice({
+  name: 'services',
+  initialState: {
+    catalog: servicesData,
+    selectedService: servicesData[0]?.key ?? null,
+    expandedEndpoints: {}
+  },
+  reducers: {
+    selectService(state, action) {
+      state.selectedService = action.payload;
+    },
+    toggleEndpoint(state, action) {
+      const { serviceKey, endpointKey } = action.payload;
+      const key = `${serviceKey}:${endpointKey}`;
+      state.expandedEndpoints[key] = !state.expandedEndpoints[key];
+    }
+  }
+});
+
+export const { selectService, toggleEndpoint } = servicesSlice.actions;
+export default servicesSlice.reducer;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import { store } from './app/store.js';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,278 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f1f5f9;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  color: white;
+  padding: 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sidebar h1 {
+  font-size: 1.25rem;
+  margin: 0;
+  font-weight: 700;
+}
+
+.sidebar nav {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.sidebar button {
+  width: 100%;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.sidebar button.active,
+.sidebar button:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.main-area {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.header {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #e2e8f0;
+  background-color: white;
+}
+
+.content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background-color: white;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 25px -20px rgba(15, 23, 42, 0.45);
+  padding: 1.5rem;
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    flex-direction: row;
+    overflow-x: auto;
+    width: 100%;
+  }
+
+  .sidebar nav {
+    display: flex;
+    gap: 0.5rem;
+  }
+}
+
+.endpoint-card {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.endpoint-header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.method-pill {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.method-GET {
+  background-color: #10b981;
+}
+
+.method-POST {
+  background-color: #2563eb;
+}
+
+.method-PUT {
+  background-color: #f97316;
+}
+
+.method-DELETE {
+  background-color: #ef4444;
+}
+
+.method-DESIGN {
+  background-color: #9333ea;
+}
+
+.code-block {
+  background-color: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 0.85rem;
+  overflow-x: auto;
+}
+
+textarea.json-input {
+  width: 100%;
+  min-height: 200px;
+  border: 1px solid #cbd5f5;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  resize: vertical;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+button.primary {
+  background-color: #2563eb;
+  color: white;
+  border: 0;
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.secondary {
+  background-color: white;
+  border: 1px solid #94a3b8;
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background-color: #e0f2fe;
+  color: #0369a1;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.badge::before {
+  content: '⦿';
+  font-size: 0.65rem;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #475569;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background-color: #e2e8f0;
+  font-size: 0.75rem;
+  color: #334155;
+}
+
+.table-like {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.table-like .row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.table-like .label {
+  width: 160px;
+  font-weight: 600;
+  color: #475569;
+}
+
+.alert {
+  border-left: 4px solid #2563eb;
+  background-color: #eff6ff;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  color: #1d4ed8;
+}
+
+.panel-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.small-text {
+  font-size: 0.85rem;
+  color: #64748b;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite-powered React + Redux workspace under `frontend/` for the patient portal API explorer
- implement reusable components, Redux slices, and static service metadata that reflect the full FHIR specification and Kafka guidance
- document usage and tooling expectations for the new frontend including local development commands and environment controls
- add Django REST endpoints that expose the Kafka communication patterns, governance, and event schema described in the specification

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*
- PYTHONDONTWRITEBYTECODE=1 python -m compileall fhir_portal


------
https://chatgpt.com/codex/tasks/task_e_68d37b9532bc8324b191bbd94ec4a6b4